### PR TITLE
increase max empty sets to allow less-frequent rules

### DIFF
--- a/src/main/java/org/dmfs/rfc5545/recur/FreqIterator.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/FreqIterator.java
@@ -30,9 +30,9 @@ public final class FreqIterator extends ByExpander
 {
     /**
      * Stop iterating (throwing an exception) if this number of empty sets passed in a line, i.e. sets that contain no elements because they have been
-     * filtered.
+     * filtered. 4320 is 3 days of minutes.
      */
-    private final static int MAX_EMPTY_SETS = 1000;
+    private final static int MAX_EMPTY_SETS = 4320;
 
     /**
      * The base frequency of the rule.

--- a/src/main/java/org/dmfs/rfc5545/recur/SanityFilter.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/SanityFilter.java
@@ -31,14 +31,14 @@ final class SanityFilter extends RuleIterator
 {
     /**
      * Stop iterating (throwing an exception) if this number of empty sets passed in a line, i.e. sets that contain no elements because they have been filtered
-     * or nothing was expanded.
+     * or nothing was expanded. 4320 is 3 days of minutes.
      */
-    private final static int MAX_EMPTY_SETS = 1000;
+    private final static int MAX_EMPTY_SETS = 4320;
 
     /**
      * The max number of filtered instances.
      */
-    private final static int MAX_FILTERED_INSTANCES = 1000;
+    private final static int MAX_FILTERED_INSTANCES = 4320;
 
     /**
      * A {@link LongArray} that contains the instances to return.

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceIteratorTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceIteratorTest.java
@@ -835,6 +835,7 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=31"));
         mTestRules.add(new TestRule("FREQ=DAILY;WKST=MO;"));
         mTestRules.add(new TestRule("FREQ=MINUTELY;INTERVAL=20;BYHOUR=9,10,11,12,13,14,15,16").setStart("20120101T101010"));
+        mTestRules.add(new TestRule("FREQ=MINUTELY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=21;BYMINUTE=0, 15;").setStart("20120101T101010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=2SA;INTERVAL=1"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=+2TH").setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=FR;BYMONTHDAY=13").setWeekdays(Calendar.FRIDAY).setMonthdays(13));


### PR DESCRIPTION
this rule throws an `java.lang.IllegalArgumentException`:

    FREQ=MINUTELY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=21;BYMINUTE=0, 15;

iterating one minute at a time, 21:00 is 1,260 minutes after 00:00
but FreqIterator gives up and throws an exception after 1,000 iterations

update `MAX_EMPTY_SETS` and `MAX_FILTERED_INSTANCES` to allow for up to three days in minutes (4,230 minutes) before giving up