### PR TITLE
Rewrite YEARLY expansion, implement #44, fixes #40

### DIFF
--- a/src/main/java/org/dmfs/rfc5545/recur/ByWeekNoFilter.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/ByWeekNoFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.recur;
+
+import org.dmfs.rfc5545.Instance;
+import org.dmfs.rfc5545.calendarmetrics.CalendarMetrics;
+import org.dmfs.rfc5545.recur.RecurrenceRule.Part;
+
+
+/**
+ * A filter that limits recurrence rules by week number. Note, neither RFC 5545 nor RFC 2445 specify filtering by week number. This is meant for internal use
+ * only.
+ *
+ * @author Marten Gajda
+ */
+final class ByWeekNoFilter implements ByFilter
+{
+    /**
+     * An array of the week numbers.
+     */
+    private final int[] mWeekNumbers;
+
+    /**
+     * The {@link CalendarMetrics} to use.
+     */
+    final CalendarMetrics mCalendarMetrics;
+
+
+    public ByWeekNoFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics)
+    {
+        mCalendarMetrics = calendarMetrics;
+        mWeekNumbers = StaticUtils.ListToSortedArray(rule.getByPart(Part.BYWEEKNO));
+    }
+
+
+    @Override
+    public boolean filter(long instance)
+    {
+        int year = Instance.year(instance);
+        int week = mCalendarMetrics.getWeekOfYear(year, Instance.month(instance), Instance.dayOfMonth(instance));
+        int weeks;
+        if (week > 10 && Instance.month(instance) == 1)
+        {
+            // week belongs to the previous iso year
+            weeks = mCalendarMetrics.getWeeksPerYear(year - 1);
+        }
+        else if (week == 1 && Instance.month(instance) > 1)
+        {
+            // week belongs to the next iso year
+            weeks = mCalendarMetrics.getWeeksPerYear(year + 1);
+        }
+        else
+        {
+            weeks = mCalendarMetrics.getWeeksPerYear(year);
+        }
+
+        return (StaticUtils.linearSearch(mWeekNumbers, week) < 0 && StaticUtils.linearSearch(mWeekNumbers, week - 1 - weeks) < 0) || week > weeks;
+    }
+}

--- a/src/main/java/org/dmfs/rfc5545/recur/ByYearDayWeeklyExpander.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/ByYearDayWeeklyExpander.java
@@ -83,7 +83,7 @@ final class ByYearDayWeeklyExpander extends ByExpander
             if (0 < actualDay && actualDay <= yearDays && newWeek == oldWeek)
             {
                 int monthAndDay = mCalendarMetrics.getMonthAndDayOfYearDay(year, actualDay);
-                addInstance(Instance.setMonthAndDayOfMonth(year, CalendarMetrics.packedMonth(monthAndDay), CalendarMetrics.dayOfMonth(monthAndDay)));
+                addInstance(Instance.setMonthAndDayOfMonth(instance, CalendarMetrics.packedMonth(monthAndDay), CalendarMetrics.dayOfMonth(monthAndDay)));
             }
             else if (0 < nextYearDay && nextYearDay <= nextYearDays && nextYearDay < 7)
             {

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceIteratorTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceIteratorTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package org.dmfs.rfc5545.recur;
@@ -498,9 +498,9 @@ public class RecurrenceIteratorTest
     {
         /*
          * Add a number of recurrence rules taken from the internet.
-		 */
+         */
 
-		/* rules limited by COUNT */
+        /* rules limited by COUNT */
         mTestRules.add(new TestRule("FREQ=DAILY;COUNT=1").setCount(1));
         mTestRules.add(new TestRule("FREQ=DAILY;COUNT=10").setCount(10));
         mTestRules.add(new TestRule("FREQ=DAILY;COUNT=5").setCount(5));
@@ -572,7 +572,7 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;COUNT=4;INTERVAL=4").setCount(4));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;BYMONTH=1;BYMONTHDAY=1;COUNT=5;WKST=SU").setCount(5).setMonths(1).setMonthdays(1));
 
-		/* rules limited by UNTIL */
+        /* rules limited by UNTIL */
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=14;UNTIL=20130620T035959Z;WKST=SU").setUntil("20130620T035959Z"));
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR;UNTIL=20130928T065959Z;WKST=SU").setUntil("20130928T065959Z").setWeekdays(
                 Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
@@ -825,7 +825,7 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=21000613T000000Z;INTERVAL=1;BYMONTH=6").setUntil("21000613T000000Z").setMonths(6));
         mTestRules.add(new TestRule("UNTIL=20070721T000000Z;FREQ=DAILY").setUntil("20070721T000000Z"));
 
-		/* unlimited test rules */
+        /* unlimited test rules */
         mTestRules.add(new TestRule("FREQ=DAILY"));
         mTestRules.add(new TestRule("FREQ=DAILY;BYDAY=SU,MO,TU,WE,TH,FR,SA"));
         mTestRules.add(new TestRule("FREQ=DAILY;BYMINUTE=0,20,40;BYHOUR=9,10,11,12,13,14,15,16"));
@@ -1043,9 +1043,9 @@ public class RecurrenceIteratorTest
                         "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31;BYSETPOS=1,2,3")
                         .setMonthdays(1, 2, 3));
 
-		/*
+        /*
          * Rules with a specific number of instances
-		 */
+         */
 
         // first 9 mondays of 2016
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO;BYMONTH=1,2;UNTIL=20161231").setStart("20160104").setUntil("20161231").setInstances(9)
@@ -1208,6 +1208,22 @@ public class RecurrenceIteratorTest
                 "FREQ=YEARLY;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;BYDAY=2TH;UNTIL=20171231")
                 .setStart("20130101").setUntil("20171231").setMonths(1).setWeekdays(Calendar.THURSDAY).setMonthdays(8, 9, 10, 11, 12, 13, 14).setInstances(5));
 
+        mTestRules.add(new TestRule(
+                "FREQ=YEARLY;BYMONTH=1,3;BYYEARDAY=1,31,59,60,61,62;COUNT=30").setStart("20180101")
+                .setMonths(1, 3)
+                .setMonthdays(1, 31, 28, 29, 2, 3)
+                .setCount(30));
+        mTestRules.add(new TestRule(
+                "FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60;UNTIL=20181231").setStart("20180101")
+                .setMonths(1, 3)
+                .setMonthdays(1, 31)
+                .setInstances(3));
+        mTestRules.add(new TestRule(
+                "FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60;BYDAY=WE;UNTIL=20181231").setStart("20180101")
+                .setMonths(1)
+                .setMonthdays(31)
+                .setInstances(1));
+
         /**
          * Interval tests
          */
@@ -1293,7 +1309,7 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20120731T000000;BYHOUR=12").setStart("20120707T000000").setInstances(1).setMonths(7).setMonthdays(7)
                 .setHours(12));
 
-		/* Tests for RSCALE */
+        /* Tests for RSCALE */
 
         mTestRules.add(new TestRule("FREQ=YEARLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=FORWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
                 .setStart("20130301").setUntil("29171231").setMonths(2, 3).setMonthdays(1, 29).setInstances(904));
@@ -1318,12 +1334,12 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=48;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=BACKWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
                 .setStart("20130228").setUntil("29171231").setMonths(2).setMonthdays(28).setInstances(227));
 
-		/* Special rules for the skip all but last test */
+        /* Special rules for the skip all but last test */
 
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=3;COUNT=10;BYMONTHDAY=10,11,12,13,14,15").setStart("20090714").setCount(10)
                 .setMonthdays(10, 11, 12, 13, 14, 15).setLastInstance("20100111"));
 
-		/* Special test for fast birthday iterator */
+        /* Special test for fast birthday iterator */
 
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
                 .setMonthdays(10).setLastInstance("20181010"));
@@ -1348,7 +1364,7 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=10;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
                 .setMonthdays(10).setLastInstance("20541010"));
 
-		/* Test time zone related issues */
+        /* Test time zone related issues */
 
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20160521T060000Z").setStart("20160520T080000", "Europe/Berlin")
                 .setInstances(2)

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceRuleYearlyTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceRuleYearlyTest.java
@@ -82,6 +82,12 @@ public final class RecurrenceRuleYearlyTest
                         instances(are(inMonth(1, 2), inWeekOfYear(1, 7), onWeekDay(MO) /* inherited weekday */)),
                         startingWith("20180101", "20180212", "20190211", "20200210", "20210104", "20210215", "20220103", "20220214"))));
 
+        assertThat(new RecurrenceRule("FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60"),
+                is(validRule(DateTime.parse("20180101"),
+                        walking(),
+                        instances(are(inMonth(12, 1, 2, 3), inWeekOfYear(1, 3, 4, 5, 8, 9), onDayOfYear(1, 14, 31, 60))),
+                        startingWith("20180101", "20180131", "20180301", "20190101", "20190114", "20190131", "20190301", "20200101", "20200114", "20200131"))));
+
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYMONTH=1,3;BYYEARDAY=1,14,31,32,60,61"),
                 is(validRule(DateTime.parse("20100101"),
                         walking(),


### PR DESCRIPTION
This commit introduces code to rewrite the expansion parts before building the iterator. This way many expanders can be simplified significantly.