### PR TITLE
Fix RecurrenceSetIterator.fastForward, fixes #61

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest.iml" group="lib-recur-hamcrest" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest.iml" group="lib-recur-hamcrest" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_main.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_main.iml" group="lib-recur-hamcrest" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_test.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_test.iml" group="lib-recur-hamcrest" />

--- a/build.gradle
+++ b/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     compile 'org.dmfs:rfc5545-datetime:0.2.4'
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile project(":lib-recur-hamcrest")
+    testCompile 'org.dmfs:jems-testing:1.23'
 }

--- a/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSetIterator.java
+++ b/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSetIterator.java
@@ -241,6 +241,8 @@ public class RecurrenceSetIterator
                 mNextInstance = next;
                 return;
             }
+            // all instances consumed
+            mInstancesInCache = 0;
         }
 
         // no (more) upcoming instances in cache, fast forward all adapters
@@ -248,6 +250,8 @@ public class RecurrenceSetIterator
         {
             instances.fastForward(until);
         }
+
+        Arrays.sort(mInstances, mAdapterComparator);
 
         if (mExceptions.length > 0)
         {
@@ -257,6 +261,7 @@ public class RecurrenceSetIterator
             {
                 exceptions.fastForward(until);
             }
+            Arrays.sort(mExceptions, mAdapterComparator);
         }
     }
 


### PR DESCRIPTION
The `fastForward` method didn't sort the instances array after fast forwarding all instance sources. The `fillInstanceCache` method, however, expects the array to be sorted by the next instance each source would return.