### PR TITLE
Fix "fast forward" to first instance, fixes #85

### DIFF
--- a/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSetIterator.java
+++ b/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSetIterator.java
@@ -119,9 +119,12 @@ public class RecurrenceSetIterator
      */
     public void fastForward(long until)
     {
-        mInstances.fastForward(until);
-        mExceptions.fastForward(until);
-        pullNext();
+        if (mNextInstance < until)
+        {
+            mInstances.fastForward(until);
+            mExceptions.fastForward(until);
+            pullNext();
+        }
     }
 
 


### PR DESCRIPTION
The fastForward method always pulled the next instance, regardless of whether the upcoming instance was already before the fast forward date or not.