### PR TITLE
Rework recurrence iteration

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -4,8 +4,18 @@
     <bytecodeTargetLevel>
       <module name="lib-recur-hamcrest_main" target="1.8" />
       <module name="lib-recur-hamcrest_test" target="1.8" />
+      <module name="lib-recur.benchmark" target="1.8" />
+      <module name="lib-recur.benchmark.jmh" target="1.8" />
+      <module name="lib-recur.benchmark.main" target="1.8" />
+      <module name="lib-recur.benchmark.test" target="1.8" />
+      <module name="lib-recur.lib-recur-hamcrest" target="1.8" />
+      <module name="lib-recur.lib-recur-hamcrest.main" target="1.8" />
+      <module name="lib-recur.lib-recur-hamcrest.test" target="1.8" />
       <module name="lib-recur_main" target="1.8" />
       <module name="lib-recur_test" target="1.8" />
+      <module name="org.dmfs.lib-recur" target="1.8" />
+      <module name="org.dmfs.lib-recur.main" target="1.8" />
+      <module name="org.dmfs.lib-recur.test" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,11 +4,20 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest.iml" group="lib-recur-hamcrest" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest.iml" group="lib-recur-hamcrest" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_main.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_main.iml" group="lib-recur-hamcrest" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_test.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur-hamcrest_test.iml" group="lib-recur-hamcrest" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.iml" filepath="$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.jmh.iml" filepath="$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.jmh.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.main.iml" filepath="$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.test.iml" filepath="$PROJECT_DIR$/.idea/modules/benchmark/lib-recur.benchmark.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur.lib-recur-hamcrest.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur.lib-recur-hamcrest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur.lib-recur-hamcrest.main.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur.lib-recur-hamcrest.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur.lib-recur-hamcrest.test.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur-hamcrest/lib-recur.lib-recur-hamcrest.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur_main.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur_main.iml" group="lib-recur" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/lib-recur_test.iml" filepath="$PROJECT_DIR$/.idea/modules/lib-recur_test.iml" group="lib-recur" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/org.dmfs.lib-recur.iml" filepath="$PROJECT_DIR$/.idea/modules/org.dmfs.lib-recur.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/org.dmfs.lib-recur.main.iml" filepath="$PROJECT_DIR$/.idea/modules/org.dmfs.lib-recur.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/org.dmfs.lib-recur.test.iml" filepath="$PROJECT_DIR$/.idea/modules/org.dmfs.lib-recur.test.iml" />
     </modules>
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -36,44 +36,135 @@ The basic use case is to iterate over all instances of a given rule starting on 
 
 The following code iterates over the instances of a recurrence rule:
 
-		RecurrenceRule rule = new RecurrenceRule("FREQ=YEARLY;BYMONTHDAY=23;BYMONTH=5");
 		
-		DateTime start = new DateTime(1982, 4 /* 0-based month numbers! */,23);
+```java
+DateTime start = RecurrenceRuleIterator it = rule.iterator(start);
 
-		RecurrenceRuleIterator it = rule.iterator(start);
+int maxInstances = 100; // limit instances for rules that recur forever
 
-		int maxInstances = 100; // limit instances for rules that recur forever
+while (it.hasNext() && (!rule.isInfinite() || maxInstances-- > 0))
+{
+    DateTime nextInstance = it.nextDateTime();
+    // do something with nextInstance
+}
+```
 
-		while (it.hasNext() && (!rule.isInfinite() || maxInstances-- > 0))
-		{
-			DateTime nextInstance = it.nextDateTime();
-			// do something with nextInstance
-		}
+### Iterating Recurrence Sets
 
-This library also supports processing of EXRULEs, RDATEs and EXDATEs, i.e. complete recurrence sets. To iterate a recurrence set use the following code:
+This library also supports processing of EXRULEs, RDATEs and EXDATEs, i.e. complete recurrence sets.
 
-		// create a recurence set
-		RecurrenceSet rset = new RecurrenceSet();
+In order to iterate a recurrence set you first compose the set from its components:
 
-		// add instances from a recurrence rule
-		// you can add any number of recurrence rules or RDATEs (RecurrenceLists).
-		rset.addInstances(new RecurrenceRuleAdapter(rule));
+```java
+RecurrenceRule rule = new RecurrenceRule("FREQ=YEARLY;BYMONTHDAY=23;BYMONTH=5");
 
-		// optionally add exceptions
-		// rset.addExceptions(new RecurrenceList(timestamps));
+DateTime firstInstance = new DateTime(1982, 4 /* 0-based month numbers! */,23);
 
-		// get an iterator
-		RecurrenceSetIterator iterator = rset.iterator(start.getTimeZone(), start.getTimestamp());
+for (DateTime instance:new RecurrenceSet(firstInstance, new RuleInstances(rule))) {
+    // do something with instance    
+}
+```
 
-		while (iterator.hasNext() && --limit >= 0)
-		{
-			long nextInstance = iterator.next();
-			// do something with nextInstance
-		}
+`RecurrenceSet` takes two `InstanceIterable` arguments the first one is expected to iterate the actual
+occurrences, the second, optional one iterates exceptions:
 
-Note: at this time RecurrenceSetIterator supports iterating timestamps only. All-day dates will be iterated as timestamps at 00:00 UTC.
+```java
+RecurrenceRule rule = new RecurrenceRule("FREQ=YEARLY;BYMONTHDAY=23;BYMONTH=5");
 
-By default the parser is very tolerant and accepts all rules that comply with RFC 5545. You can use other modes to ensure a certain compliance level:
+DateTime firstInstance = new DateTime(1982, 4 /* 0-based month numbers! */,23);
+
+for (DateTime instance:
+    new RecurrenceSet(firstInstance,
+        new RuleInstances(rule),
+        new InstanceList(exceptions))) {
+    // do something with instance    
+}
+```
+
+You can compose multiple rules or `InstanceList`s using `Composite` like this
+
+```java
+RecurrenceRule rule1 = new RecurrenceRule("FREQ=YEARLY;BYMONTHDAY=23;BYMONTH=5");
+RecurrenceRule rule2 = new RecurrenceRule("FREQ=MONTHLY;BYMONTHDAY=20");
+
+DateTime firstInstance = new DateTime(1982, 4 /* 0-based month numbers! */,23);
+
+for (DateTime instance:
+    new RecurrenceSet(firstInstance,
+        new Composite(new RuleInstances(rule1), new RuleInstances(rule2)),
+        new InstanceList(exceptions))) {
+    // do something with instance    
+}
+```
+
+or simply by providing a `List` of `InstanceIterable`s:
+
+```java
+RecurrenceRule rule1 = new RecurrenceRule("FREQ=YEARLY;BYMONTHDAY=23;BYMONTH=5");
+RecurrenceRule rule2 = new RecurrenceRule("FREQ=MONTHLY;BYMONTHDAY=20");
+
+DateTime firstInstance = new DateTime(1982, 4 /* 0-based month numbers! */,23);
+
+for (DateTime instance:
+    new RecurrenceSet(firstInstance,
+        List.of(new RuleInstances(rule1), new RuleInstances(rule2)),
+        new InstanceList(exceptions))) {
+    // do something with instance    
+}
+```
+
+#### Handling first instances that don't match the RRULE
+
+Note that `RuleInstances` does not iterate the start date if it doesn't match the RRULE. If you want to
+iterate any non-synchronized first date, use `FirstAndRuleInstances` instead!
+
+```java
+new RecurrenceSet(DateTime.parse("19820523"),
+    new RuleInstances(
+        new RecurrenceRule("FREQ=YEARLY;BYMONTHDAY=24;BYMONTH=5")))) {
+    // do something with instance    
+}
+```
+results in
+```
+19830524,19840524,19850524…
+```
+Note that `19820523` is not among the results.
+
+However,
+
+```java
+new RecurrenceSet(DateTime.parse("19820523"),
+    new RuleInstances(
+        new FirstAndRuleInstances("FREQ=YEARLY;BYMONTHDAY=24;BYMONTH=5")))) {
+    // do something with instance    
+}
+```
+results in
+```
+19820523,19830524,19840524,19850524…
+```
+
+
+#### Dealing with infinite rules
+
+Be aware that RRULEs are infinite if they specify neither `COUNT` nor `UNTIL`. This might easily result in an infinite loop when you just iterate over the recurrence set like above.
+
+One way to address this is by adding a decorator like `First` from the `jems2`  library:
+
+```java
+RecurrenceRule rule = new RecurrenceRule("FREQ=YEARLY;BYMONTHDAY=23;BYMONTH=5");
+DateTime firstInstance = new DateTime(1982, 4 /* 0-based month numbers! */,23);
+for (DateTime instance: new First(1000, new RecurrenceSet(firstInstance, new RuleInstances(rule)))) {
+    // do something with instance    
+}
+```
+
+This will always stop iterating after at most 1000 instances.
+
+### Strict and lax parsing
+
+By default, the parser is very tolerant and accepts all rules that comply with RFC 5545. You can use other modes to ensure a certain compliance level:
 
 		RecurrenceRule rule1 = new RecurrenceRule("FREQ=WEEKLY;BYWEEKNO=1,2,3,4;BYDAY=SU", RfcMode.RFC2445_STRICT);
 		// -> will iterate Sunday in the first four weeks of the year
@@ -148,4 +239,4 @@ There are at least two other implentations of recurrence iterators for Java:
 
 ## License
 
-Copyright (c) Marten Gajda 2015, licensed under Apache2.
+Copyright (c) Marten Gajda 2022, licensed under Apache2.

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java'
-    id "me.champeau.gradle.jmh" version "0.5.1"
+    id "me.champeau.jmh" version "0.6.8"
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    jmh 'org.dmfs:jems:1.41'
+    jmh 'org.dmfs:jems2:2.11.1'
     jmh rootProject
 }
 

--- a/benchmark/src/jmh/java/org/dmfs/rfc5545/recur/RecurrenceRuleExpansion.java
+++ b/benchmark/src/jmh/java/org/dmfs/rfc5545/recur/RecurrenceRuleExpansion.java
@@ -18,16 +18,7 @@
 package org.dmfs.rfc5545.recur;
 
 import org.dmfs.rfc5545.DateTime;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.*;
 
 import java.util.TimeZone;
 
@@ -49,20 +40,20 @@ public class RecurrenceRuleExpansion
         int iterations;
 
         @Param({
-                "FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=24",
-                "FREQ=MONTHLY;BYMONTH=12;BYMONTHDAY=24",
-                "FREQ=YEARLY;BYDAY=-2SU,-3SU,-4SU,-5SU",
-                "FREQ=MONTHLY;INTERVAL=3;BYDAY=2WE",
-                "FREQ=YEARLY;INTERVAL=1;BYDAY=WE;BYMONTHDAY=25,26,27,21,22,23,24;BYMONTH=4",
-                "FREQ=MONTHLY;INTERVAL=1;BYDAY=WE;BYMONTHDAY=25,26,27,21,22,23,24;BYMONTH=4",
-                "FREQ=YEARLY;BYDAY=MO",
-                "FREQ=MONTHLY;BYDAY=MO",
-                "FREQ=WEEKLY;BYDAY=MO",
-                "FREQ=DAILY;BYDAY=MO",
-                "FREQ=YEARLY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
-                "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
-                "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
-                "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
+            "FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=24",
+            "FREQ=MONTHLY;BYMONTH=12;BYMONTHDAY=24",
+            "FREQ=YEARLY;BYDAY=-2SU,-3SU,-4SU,-5SU",
+            "FREQ=MONTHLY;INTERVAL=3;BYDAY=2WE",
+            "FREQ=YEARLY;INTERVAL=1;BYDAY=WE;BYMONTHDAY=25,26,27,21,22,23,24;BYMONTH=4",
+            "FREQ=MONTHLY;INTERVAL=1;BYDAY=WE;BYMONTHDAY=25,26,27,21,22,23,24;BYMONTH=4",
+            "FREQ=YEARLY;BYDAY=MO",
+            "FREQ=MONTHLY;BYDAY=MO",
+            "FREQ=WEEKLY;BYDAY=MO",
+            "FREQ=DAILY;BYDAY=MO",
+            "FREQ=YEARLY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
+            "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
+            "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
+            "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR,SA,SU",
         })
         String rule;
 

--- a/benchmark/src/jmh/java/org/dmfs/rfc5545/recur/RecurrenceSetIterableExpansion.java
+++ b/benchmark/src/jmh/java/org/dmfs/rfc5545/recur/RecurrenceSetIterableExpansion.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.recur;
+
+import org.dmfs.jems2.FragileFunction;
+import org.dmfs.jems2.Function;
+import org.dmfs.jems2.iterable.DelegatingIterable;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
+import org.dmfs.jems2.iterable.Sieved;
+import org.dmfs.jems2.predicate.Not;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.iterable.InstanceIterable;
+import org.dmfs.rfc5545.iterable.RecurrenceSet;
+import org.dmfs.rfc5545.iterable.instanceiterable.FirstAndRuleInstances;
+import org.openjdk.jmh.annotations.*;
+
+
+/**
+ * @author marten
+ */
+@Warmup(iterations = 5, time = 5)
+@Measurement(iterations = 5, time = 5)
+@Fork(5)
+@BenchmarkMode(Mode.Throughput)
+public class RecurrenceSetIterableExpansion
+{
+    @State(Scope.Benchmark)
+    public static class BenchmarkState
+    {
+
+        @Param({ "1", "1000" })
+        int iterations;
+
+        @Param({
+            "FREQ=DAILY;BYDAY=MO,TU,WE",
+            "FREQ=DAILY;BYDAY=MO,TU,WE" + ":" + "FREQ=DAILY;BYDAY=WE,TH,FR" + ":" + "FREQ=DAILY;BYDAY=SU,SO" })
+        String instances;
+
+        @Param({
+            "",
+            "FREQ=DAILY;BYDAY=MO",
+            "FREQ=DAILY;BYDAY=MO" + ":" + "FREQ=DAILY;BYDAY=WE" + ":" + "FREQ=DAILY;BYDAY=WE,FR" })
+        String exceptions;
+
+        RecurrenceSet recurrenceSet;
+
+
+        @Setup
+        public void setup()
+        {
+            recurrenceSet = new RecurrenceSet(DateTime.nowAndHere(), new RuleAdapters(instances), new RuleAdapters(exceptions));
+        }
+    }
+
+
+    @Benchmark
+    public long testExpansion(BenchmarkState state)
+    {
+        long last = 0L;
+        int count = state.iterations;
+        for (DateTime dt : state.recurrenceSet)
+        {
+            last = dt.getTimestamp();
+            if (--count == 0)
+            {
+                break;
+            }
+        }
+        return last;
+    }
+
+
+    private static class RuleAdapters extends DelegatingIterable<InstanceIterable>
+    {
+
+        public RuleAdapters(String ruleString)
+        {
+            super(new Mapped<>(
+                FirstAndRuleInstances::new,
+                new Mapped<>(
+                    new Unchecked<>(RecurrenceRule::new),
+                    new Sieved<>(new Not<>(String::isEmpty),
+                        new Seq<>(ruleString.split(":"))))));
+        }
+    }
+
+
+    /**
+     * TODO: this should be provided by jems
+     */
+    private static class Unchecked<Arg, Res> implements Function<Arg, Res>
+    {
+
+        private final FragileFunction<? super Arg, ? extends Res, ?> mDelegate;
+
+
+        private Unchecked(FragileFunction<? super Arg, ? extends Res, ?> mDelegate)
+        {
+            this.mDelegate = mDelegate;
+        }
+
+
+        @Override
+        public Res value(Arg arg)
+        {
+            try
+            {
+                return mDelegate.value(arg);
+            }
+            catch (Throwable throwable)
+            {
+                throw new RuntimeException("Error", throwable);
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,15 @@ allprojects {
 }
 
 dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     api 'org.dmfs:rfc5545-datetime:0.3'
-    implementation 'org.dmfs:jems:1.41'
-    testImplementation group: 'junit', name: 'junit', version: '4.11'
+    implementation 'org.dmfs:jems2:2.11.1'
     testImplementation project("lib-recur-hamcrest")
-    testImplementation 'org.dmfs:jems-testing:1.41'
+    testImplementation 'org.dmfs:jems2-testing:2.11.1'
+}
+
+
+test {
+    useJUnitPlatform()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/lib-recur-hamcrest/build.gradle
+++ b/lib-recur-hamcrest/build.gradle
@@ -7,8 +7,8 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
-    api 'org.hamcrest:hamcrest-all:1.3'
-    api 'org.dmfs:jems-testing:1.33'
-    implementation 'org.dmfs:jems:1.33'
+    api 'org.hamcrest:hamcrest:2.2'
+    api 'org.dmfs:jems2-testing:2.11.1'
+    implementation 'org.dmfs:jems2:2.11.1'
     api rootProject
 }

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/GeneratorMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/GeneratorMatcher.java
@@ -17,10 +17,10 @@
 
 package org.dmfs.rfc5545.hamcrest;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.generatable.Generatable;
-import org.dmfs.jems.hamcrest.matchers.GeneratableMatcher;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.Generatable;
+import org.dmfs.jems2.hamcrest.matchers.generatable.GeneratableMatcher;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.recur.RecurrenceRule;
 import org.hamcrest.Description;

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/RecurrenceRuleMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/RecurrenceRuleMatcher.java
@@ -17,10 +17,10 @@
 
 package org.dmfs.rfc5545.hamcrest;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.function.Function;
-import org.dmfs.jems.iterable.composite.Joined;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.Function;
+import org.dmfs.jems2.iterable.Joined;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.recur.RecurrenceRule;
 import org.hamcrest.CoreMatchers;
@@ -31,9 +31,7 @@ import org.hamcrest.core.AllOf;
 
 import static org.dmfs.rfc5545.hamcrest.GeneratorMatcher.generates;
 import static org.dmfs.rfc5545.hamcrest.IncreasingMatcher.increasing;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.describedAs;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 
 /**
@@ -92,11 +90,6 @@ public final class RecurrenceRuleMatcher
 
     /**
      * This is just an alias to {@link CoreMatchers#is(Matcher)} which works better when being uses in a plural context.
-     *
-     * @param matcher
-     * @param <T>
-     *
-     * @return
      */
     public static <T> Matcher<T> are(Matcher<T> matcher)
     {
@@ -108,11 +101,6 @@ public final class RecurrenceRuleMatcher
 
     /**
      * This is just an alias to {@link CoreMatchers#is(Matcher)} which works better when being uses in a plural context.
-     *
-     * @param matcher
-     * @param <T>
-     *
-     * @return
      */
     @SafeVarargs
     public static <T> Matcher<T> are(Matcher<T>... matcher)

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfMonthMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfMonthMatcher.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.rfc5545.hamcrest.datetime;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -38,7 +38,7 @@ public final class DayOfMonthMatcher extends FeatureMatcher<DateTime, Integer>
      * Constructor
      *
      * @param subMatcher
-     *         The matcher to apply to the feature
+     *     The matcher to apply to the feature
      */
     public DayOfMonthMatcher(Matcher<Integer> subMatcher)
     {

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfYearMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfYearMatcher.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.rfc5545.hamcrest.datetime;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -35,7 +35,7 @@ public final class DayOfYearMatcher extends FeatureMatcher<DateTime, Integer>
      * Constructor
      *
      * @param subMatcher
-     *         The matcher to apply to the feature
+     *     The matcher to apply to the feature
      */
     public DayOfYearMatcher(Matcher<Integer> subMatcher)
     {

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/MonthMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/MonthMatcher.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.rfc5545.hamcrest.datetime;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -35,7 +35,7 @@ public final class MonthMatcher extends FeatureMatcher<DateTime, Integer>
      * Constructor
      *
      * @param subMatcher
-     *         The matcher to apply to the feature
+     *     The matcher to apply to the feature
      */
     public MonthMatcher(Matcher<Integer> subMatcher)
     {

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/WeekDayMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/WeekDayMatcher.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.rfc5545.hamcrest.datetime;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Weekday;
 import org.hamcrest.FeatureMatcher;
@@ -36,7 +36,7 @@ public final class WeekDayMatcher extends FeatureMatcher<DateTime, Weekday>
      * Constructor
      *
      * @param subMatcher
-     *         The matcher to apply to the feature
+     *     The matcher to apply to the feature
      */
     public WeekDayMatcher(Matcher<Weekday> subMatcher)
     {

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/WeekOfYearMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/WeekOfYearMatcher.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.rfc5545.hamcrest.datetime;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -38,7 +38,7 @@ public final class WeekOfYearMatcher extends FeatureMatcher<DateTime, Integer>
      * Constructor
      *
      * @param subMatcher
-     *         The matcher to apply to the feature
+     *     The matcher to apply to the feature
      */
     public WeekOfYearMatcher(Matcher<Integer> subMatcher)
     {

--- a/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/YearMatcher.java
+++ b/lib-recur-hamcrest/src/main/java/org/dmfs/rfc5545/hamcrest/datetime/YearMatcher.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.rfc5545.hamcrest.datetime;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.rfc5545.DateTime;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -38,7 +38,7 @@ public final class YearMatcher extends FeatureMatcher<DateTime, Integer>
      * Constructor
      *
      * @param subMatcher
-     *         The matcher to apply to the feature
+     *     The matcher to apply to the feature
      */
     public YearMatcher(Matcher<Integer> subMatcher)
     {

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/ResultsMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/ResultsMatcherTest.java
@@ -23,9 +23,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.ResultsMatcher.results;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
@@ -44,20 +42,20 @@ public class ResultsMatcherTest
     public void test() throws Exception
     {
         assertThat(results(DateTime.parse("20180101"), 10),
-                AllOf.<Matcher<RecurrenceRule>>allOf(
-                        matches(new RecurrenceRule("FREQ=DAILY;COUNT=10")),
-                        mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=9"), "number of instances was <9>"),
-                        mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=12"), "number of instances was <12>"),
-                        describesAs("number of instances is <10>")
-                ));
+            AllOf.<Matcher<RecurrenceRule>>allOf(
+                matches(new RecurrenceRule("FREQ=DAILY;COUNT=10")),
+                mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=9"), "number of instances was <9>"),
+                mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=12"), "number of instances was <12>"),
+                describesAs("number of instances is <10>")
+            ));
 
         assertThat(results(DateTime.parse("20180101"), lessThan(20)),
-                AllOf.<Matcher<RecurrenceRule>>allOf(
-                        matches(new RecurrenceRule("FREQ=DAILY;COUNT=1")),
-                        matches(new RecurrenceRule("FREQ=DAILY;COUNT=19")),
-                        mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=20"), "number of instances <20> was equal to <20>"),
-                        mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=21"), "number of instances <21> was greater than <20>"),
-                        describesAs("number of instances is a value less than <20>")
-                ));
+            AllOf.<Matcher<RecurrenceRule>>allOf(
+                matches(new RecurrenceRule("FREQ=DAILY;COUNT=1")),
+                matches(new RecurrenceRule("FREQ=DAILY;COUNT=19")),
+                mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=20"), "number of instances <20> was equal to <20>"),
+                mismatches(new RecurrenceRule("FREQ=DAILY;COUNT=21"), "number of instances <21> was greater than <20>"),
+                describesAs("number of instances is a value less than <20>")
+            ));
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/AfterMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/AfterMatcherTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.AfterMatcher.after;
 import static org.junit.Assert.assertThat;
 
@@ -41,19 +39,19 @@ public class AfterMatcherTest
     public void test() throws Exception
     {
         assertThat(after(DateTime.parse("20180101T010000Z")),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180101T010001Z")),
-                        mismatches(DateTime.parse("20180101T005959Z"), "not after 20180101T010000Z"),
-                        mismatches(DateTime.parse("20180101T010000Z"), "not after 20180101T010000Z"),
-                        describesAs("after 20180101T010000Z")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180101T010001Z")),
+                mismatches(DateTime.parse("20180101T005959Z"), "not after 20180101T010000Z"),
+                mismatches(DateTime.parse("20180101T010000Z"), "not after 20180101T010000Z"),
+                describesAs("after 20180101T010000Z")
+            ));
 
         assertThat(after("20180101T010000Z"),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180101T010001Z")),
-                        mismatches(DateTime.parse("20180101T005959Z"), "not after 20180101T010000Z"),
-                        mismatches(DateTime.parse("20180101T010000Z"), "not after 20180101T010000Z"),
-                        describesAs("after 20180101T010000Z")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180101T010001Z")),
+                mismatches(DateTime.parse("20180101T005959Z"), "not after 20180101T010000Z"),
+                mismatches(DateTime.parse("20180101T010000Z"), "not after 20180101T010000Z"),
+                describesAs("after 20180101T010000Z")
+            ));
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/BeforeMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/BeforeMatcherTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.BeforeMatcher.before;
 import static org.junit.Assert.assertThat;
 
@@ -41,19 +39,19 @@ public class BeforeMatcherTest
     public void test() throws Exception
     {
         assertThat(before(DateTime.parse("20180101T010000Z")),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180101T000059Z")),
-                        mismatches(DateTime.parse("20180101T010001Z"), "not before 20180101T010000Z"),
-                        mismatches(DateTime.parse("20180101T010000Z"), "not before 20180101T010000Z"),
-                        describesAs("before 20180101T010000Z")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180101T000059Z")),
+                mismatches(DateTime.parse("20180101T010001Z"), "not before 20180101T010000Z"),
+                mismatches(DateTime.parse("20180101T010000Z"), "not before 20180101T010000Z"),
+                describesAs("before 20180101T010000Z")
+            ));
 
         assertThat(before("20180101T010000Z"),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180101T000059Z")),
-                        mismatches(DateTime.parse("20180101T010001Z"), "not before 20180101T010000Z"),
-                        mismatches(DateTime.parse("20180101T010000Z"), "not before 20180101T010000Z"),
-                        describesAs("before 20180101T010000Z")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180101T000059Z")),
+                mismatches(DateTime.parse("20180101T010001Z"), "not before 20180101T010000Z"),
+                mismatches(DateTime.parse("20180101T010000Z"), "not before 20180101T010000Z"),
+                describesAs("before 20180101T010000Z")
+            ));
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfMonthMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfMonthMatcherTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.DayOfMonthMatcher.onDayOfMonth;
 import static org.junit.Assert.assertThat;
 
@@ -41,22 +39,22 @@ public class DayOfMonthMatcherTest
     public void test() throws Exception
     {
         assertThat(onDayOfMonth(10),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180710T010001Z")),
-                        mismatches(DateTime.parse("20181001T005959Z"), "day of month was <1>"),
-                        mismatches(DateTime.parse("20181011T010000Z"), "day of month was <11>"),
-                        describesAs("day of month (<10>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180710T010001Z")),
+                mismatches(DateTime.parse("20181001T005959Z"), "day of month was <1>"),
+                mismatches(DateTime.parse("20181011T010000Z"), "day of month was <11>"),
+                describesAs("day of month (<10>)")
+            ));
         assertThat(onDayOfMonth(6, 8, 10),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180706T010001Z")),
-                        matches(DateTime.parse("20180708T010002Z")),
-                        matches(DateTime.parse("20180710T010003Z")),
-                        mismatches(DateTime.parse("20180605T005959Z"), "day of month was <5>"),
-                        mismatches(DateTime.parse("20180811T005958Z"), "day of month was <11>"),
-                        mismatches(DateTime.parse("20181009T005957Z"), "day of month was <9>"),
-                        mismatches(DateTime.parse("20180907T010000Z"), "day of month was <7>"),
-                        describesAs("day of month (<6> or <8> or <10>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180706T010001Z")),
+                matches(DateTime.parse("20180708T010002Z")),
+                matches(DateTime.parse("20180710T010003Z")),
+                mismatches(DateTime.parse("20180605T005959Z"), "day of month was <5>"),
+                mismatches(DateTime.parse("20180811T005958Z"), "day of month was <11>"),
+                mismatches(DateTime.parse("20181009T005957Z"), "day of month was <9>"),
+                mismatches(DateTime.parse("20180907T010000Z"), "day of month was <7>"),
+                describesAs("day of month (<6> or <8> or <10>)")
+            ));
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfYearMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/DayOfYearMatcherTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.DayOfYearMatcher.onDayOfYear;
 import static org.junit.Assert.assertThat;
 
@@ -41,23 +39,23 @@ public class DayOfYearMatcherTest
     public void test() throws Exception
     {
         assertThat(onDayOfYear(10),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180110T010001Z")),
-                        mismatches(DateTime.parse("20180111T005959Z"), "day of year was <11>"),
-                        mismatches(DateTime.parse("20180109T010000Z"), "day of year was <9>"),
-                        describesAs("day of year (<10>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180110T010001Z")),
+                mismatches(DateTime.parse("20180111T005959Z"), "day of year was <11>"),
+                mismatches(DateTime.parse("20180109T010000Z"), "day of year was <9>"),
+                describesAs("day of year (<10>)")
+            ));
         assertThat(onDayOfYear(1, 8, 365),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180101T010001Z")),
-                        matches(DateTime.parse("20180108T010002Z")),
-                        matches(DateTime.parse("20181231T010003Z")),
-                        mismatches(DateTime.parse("20180102T005959Z"), "day of year was <2>"),
-                        mismatches(DateTime.parse("20180107T005959Z"), "day of year was <7>"),
-                        mismatches(DateTime.parse("20180109T005959Z"), "day of year was <9>"),
-                        mismatches(DateTime.parse("20180228T005958Z"), "day of year was <59>"),
-                        mismatches(DateTime.parse("20181230T005957Z"), "day of year was <364>"),
-                        describesAs("day of year (<1> or <8> or <365>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180101T010001Z")),
+                matches(DateTime.parse("20180108T010002Z")),
+                matches(DateTime.parse("20181231T010003Z")),
+                mismatches(DateTime.parse("20180102T005959Z"), "day of year was <2>"),
+                mismatches(DateTime.parse("20180107T005959Z"), "day of year was <7>"),
+                mismatches(DateTime.parse("20180109T005959Z"), "day of year was <9>"),
+                mismatches(DateTime.parse("20180228T005958Z"), "day of year was <59>"),
+                mismatches(DateTime.parse("20181230T005957Z"), "day of year was <364>"),
+                describesAs("day of year (<1> or <8> or <365>)")
+            ));
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/MonthMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/MonthMatcherTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.MonthMatcher.inMonth;
 import static org.junit.Assert.assertThat;
 
@@ -41,22 +39,22 @@ public class MonthMatcherTest
     public void test() throws Exception
     {
         assertThat(inMonth(10),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20181001T010001Z")),
-                        mismatches(DateTime.parse("20180901T005959Z"), "month was <9>"),
-                        mismatches(DateTime.parse("20181101T010000Z"), "month was <11>"),
-                        describesAs("month (<10>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20181001T010001Z")),
+                mismatches(DateTime.parse("20180901T005959Z"), "month was <9>"),
+                mismatches(DateTime.parse("20181101T010000Z"), "month was <11>"),
+                describesAs("month (<10>)")
+            ));
         assertThat(inMonth(6, 8, 10),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20181001T010001Z")),
-                        matches(DateTime.parse("20180801T010002Z")),
-                        matches(DateTime.parse("20180601T010003Z")),
-                        mismatches(DateTime.parse("20180501T005959Z"), "month was <5>"),
-                        mismatches(DateTime.parse("20180701T005958Z"), "month was <7>"),
-                        mismatches(DateTime.parse("20180901T005957Z"), "month was <9>"),
-                        mismatches(DateTime.parse("20181101T010000Z"), "month was <11>"),
-                        describesAs("month (<6> or <8> or <10>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20181001T010001Z")),
+                matches(DateTime.parse("20180801T010002Z")),
+                matches(DateTime.parse("20180601T010003Z")),
+                mismatches(DateTime.parse("20180501T005959Z"), "month was <5>"),
+                mismatches(DateTime.parse("20180701T005958Z"), "month was <7>"),
+                mismatches(DateTime.parse("20180901T005957Z"), "month was <9>"),
+                mismatches(DateTime.parse("20181101T010000Z"), "month was <11>"),
+                describesAs("month (<6> or <8> or <10>)")
+            ));
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/WeekDayMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/WeekDayMatcherTest.java
@@ -23,9 +23,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.WeekDayMatcher.onWeekDay;
 import static org.junit.Assert.assertThat;
 
@@ -41,23 +39,23 @@ public class WeekDayMatcherTest
     public void test() throws Exception
     {
         assertThat(onWeekDay(Weekday.WE),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180808T010001Z")),
-                        mismatches(DateTime.parse("20180809T005959Z"), "weekday was <TH>"),
-                        mismatches(DateTime.parse("20180807T010000Z"), "weekday was <TU>"),
-                        describesAs("weekday (<WE>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180808T010001Z")),
+                mismatches(DateTime.parse("20180809T005959Z"), "weekday was <TH>"),
+                mismatches(DateTime.parse("20180807T010000Z"), "weekday was <TU>"),
+                describesAs("weekday (<WE>)")
+            ));
         assertThat(onWeekDay(Weekday.MO, Weekday.WE, Weekday.FR),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180808T010001Z")),
-                        matches(DateTime.parse("20180806T010002Z")),
-                        matches(DateTime.parse("20180810T010003Z")),
-                        mismatches(DateTime.parse("20180805T005959Z"), "weekday was <SU>"),
-                        mismatches(DateTime.parse("20180804T005958Z"), "weekday was <SA>"),
-                        mismatches(DateTime.parse("20180814T005957Z"), "weekday was <TU>"),
-                        mismatches(DateTime.parse("20180816T010000Z"), "weekday was <TH>"),
-                        describesAs("weekday (<MO> or <WE> or <FR>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180808T010001Z")),
+                matches(DateTime.parse("20180806T010002Z")),
+                matches(DateTime.parse("20180810T010003Z")),
+                mismatches(DateTime.parse("20180805T005959Z"), "weekday was <SU>"),
+                mismatches(DateTime.parse("20180804T005958Z"), "weekday was <SA>"),
+                mismatches(DateTime.parse("20180814T005957Z"), "weekday was <TU>"),
+                mismatches(DateTime.parse("20180816T010000Z"), "weekday was <TH>"),
+                describesAs("weekday (<MO> or <WE> or <FR>)")
+            ));
 
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/WeekOfYearMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/WeekOfYearMatcherTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.WeekOfYearMatcher.inWeekOfYear;
 import static org.junit.Assert.assertThat;
 
@@ -40,27 +38,27 @@ public class WeekOfYearMatcherTest
     public void test() throws Exception
     {
         assertThat(inWeekOfYear(16),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180418T010001Z")),
-                        mismatches(DateTime.parse("20180415T005959Z"), "week of year was <15>"),
-                        mismatches(DateTime.parse("20180423T010000Z"), "week of year was <17>"),
-                        describesAs("week of year (<16>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180418T010001Z")),
+                mismatches(DateTime.parse("20180415T005959Z"), "week of year was <15>"),
+                mismatches(DateTime.parse("20180423T010000Z"), "week of year was <17>"),
+                describesAs("week of year (<16>)")
+            ));
         assertThat(inWeekOfYear(1, 16, 52),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20180101T010001Z")),
-                        matches(DateTime.parse("20180418T010001Z")),
-                        matches(DateTime.parse("20181230T010001Z")),
-                        matches(DateTime.parse("20181231T010001Z")),
-                        matches(DateTime.parse("20190101T010001Z")),
-                        mismatches(DateTime.parse("20180108T010001Z"), "week of year was <2>"),
-                        mismatches(DateTime.parse("20180415T005959Z"), "week of year was <15>"),
-                        mismatches(DateTime.parse("20180423T010000Z"), "week of year was <17>"),
-                        mismatches(DateTime.parse("20181223T010001Z"), "week of year was <51>"),
-                        mismatches(DateTime.parse("20181223T010001Z"), "week of year was <51>"),
-                        mismatches(DateTime.parse("20190107T010001Z"), "week of year was <2>"),
-                        describesAs("week of year (<1> or <16> or <52>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20180101T010001Z")),
+                matches(DateTime.parse("20180418T010001Z")),
+                matches(DateTime.parse("20181230T010001Z")),
+                matches(DateTime.parse("20181231T010001Z")),
+                matches(DateTime.parse("20190101T010001Z")),
+                mismatches(DateTime.parse("20180108T010001Z"), "week of year was <2>"),
+                mismatches(DateTime.parse("20180415T005959Z"), "week of year was <15>"),
+                mismatches(DateTime.parse("20180423T010000Z"), "week of year was <17>"),
+                mismatches(DateTime.parse("20181223T010001Z"), "week of year was <51>"),
+                mismatches(DateTime.parse("20181223T010001Z"), "week of year was <51>"),
+                mismatches(DateTime.parse("20190107T010001Z"), "week of year was <2>"),
+                describesAs("week of year (<1> or <16> or <52>)")
+            ));
 
     }
 }

--- a/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/YearMatcherTest.java
+++ b/lib-recur-hamcrest/src/test/java/org/dmfs/rfc5545/hamcrest/datetime/YearMatcherTest.java
@@ -22,9 +22,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
-import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems2.hamcrest.matchers.matcher.MatcherMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.YearMatcher.inYear;
 import static org.junit.Assert.assertThat;
 
@@ -40,23 +38,23 @@ public class YearMatcherTest
     public void test() throws Exception
     {
         assertThat(inYear(2018),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20181001T010001Z")),
-                        mismatches(DateTime.parse("20210901T005959Z"), "year was <2021>"),
-                        mismatches(DateTime.parse("20171101T010000Z"), "year was <2017>"),
-                        describesAs("year (<2018>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20181001T010001Z")),
+                mismatches(DateTime.parse("20210901T005959Z"), "year was <2021>"),
+                mismatches(DateTime.parse("20171101T010000Z"), "year was <2017>"),
+                describesAs("year (<2018>)")
+            ));
         assertThat(inYear(2018, 2019, 2020),
-                AllOf.<Matcher<DateTime>>allOf(
-                        matches(DateTime.parse("20181001T010001Z")),
-                        matches(DateTime.parse("20190801T010002Z")),
-                        matches(DateTime.parse("20200601T010003Z")),
-                        mismatches(DateTime.parse("20110501T005959Z"), "year was <2011>"),
-                        mismatches(DateTime.parse("20170701T005958Z"), "year was <2017>"),
-                        mismatches(DateTime.parse("20210901T005957Z"), "year was <2021>"),
-                        mismatches(DateTime.parse("20301101T010000Z"), "year was <2030>"),
-                        describesAs("year (<2018> or <2019> or <2020>)")
-                ));
+            AllOf.<Matcher<DateTime>>allOf(
+                matches(DateTime.parse("20181001T010001Z")),
+                matches(DateTime.parse("20190801T010002Z")),
+                matches(DateTime.parse("20200601T010003Z")),
+                mismatches(DateTime.parse("20110501T005959Z"), "year was <2011>"),
+                mismatches(DateTime.parse("20170701T005958Z"), "year was <2017>"),
+                mismatches(DateTime.parse("20210901T005957Z"), "year was <2021>"),
+                mismatches(DateTime.parse("20301101T010000Z"), "year was <2030>"),
+                describesAs("year (<2018> or <2019> or <2020>)")
+            ));
 
     }
 }

--- a/src/main/java/org/dmfs/rfc5545/iterable/InstanceIterable.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/InstanceIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Marten Gajda <marten@dmfs.org>
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,33 +15,18 @@
  * limitations under the License.
  */
 
-package org.dmfs.rfc5545.recurrenceset;
+package org.dmfs.rfc5545.iterable;
 
-import java.util.NoSuchElementException;
+import org.dmfs.rfc5545.DateTime;
 
 
 /**
- * An {@link AbstractRecurrenceAdapter.InstanceIterator} without any instances.
+ * An {@link Iterable} of recurring instances.
  */
-@Deprecated
-public final class EmptyIterator implements AbstractRecurrenceAdapter.InstanceIterator
+public interface InstanceIterable
 {
-    @Override
-    public boolean hasNext()
-    {
-        return false;
-    }
-
-
-    @Override
-    public long next()
-    {
-        throw new NoSuchElementException("No elements to iterate");
-    }
-
-
-    @Override
-    public void fastForward(long until)
-    {
-    }
+    /**
+     * Return an {@link InstanceIterator} for the given first instance.
+     */
+    InstanceIterator iterator(DateTime firstInstance);
 }

--- a/src/main/java/org/dmfs/rfc5545/iterable/InstanceIterator.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/InstanceIterator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.iterable;
+
+public interface InstanceIterator
+{
+    /**
+     * Returns {@code true} if there is at least one more instance to iterate and {@code false} otherwise.
+     */
+    boolean hasNext();
+
+    /**
+     * Get the next instance (in milliseconds since the epoch) of this set. Do not call this if {@link #hasNext()} returns {@code false}.
+     */
+    long next();
+
+    /**
+     * Skip all instances till {@code until}. If  {@code until} is an instance itself it will be the next iterated instance. If the rule doesn't
+     * recur till that date the next call to {@link #hasNext()} will return {@code false}.
+     */
+    void fastForward(long until);
+}

--- a/src/main/java/org/dmfs/rfc5545/iterable/RecurrenceSet.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/RecurrenceSet.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.iterable;
+
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.iterable.instanceiterable.Composite;
+import org.dmfs.rfc5545.iterable.instanceiterable.EmptyIterable;
+import org.dmfs.rfc5545.iterable.instanceiterator.EffectiveInstancesIterator;
+
+import java.util.Iterator;
+import java.util.TimeZone;
+
+
+/**
+ * An {@link Iterable} of a recurrence set.
+ * <p>
+ * The recurrence set is determined from a number of {@link InstanceIterable}s providing instances and exceptions.
+ */
+public final class RecurrenceSet implements Iterable<DateTime>
+{
+    private final DateTime mFirst;
+    private final InstanceIterable mInstances;
+    private final InstanceIterable mExceptions;
+
+
+    public RecurrenceSet(TimeZone timeZone, long firstInstanceTimeStamp, InstanceIterable instances)
+    {
+        this(new DateTime(timeZone, firstInstanceTimeStamp), instances, EmptyIterable.INSTANCE);
+    }
+
+
+    public RecurrenceSet(TimeZone timeZone, long firstInstanceTimeStamp, Iterable<InstanceIterable> instances)
+    {
+        this(new DateTime(timeZone, firstInstanceTimeStamp), new Composite(instances),
+            EmptyIterable.INSTANCE);
+    }
+
+
+    public RecurrenceSet(TimeZone timeZone, long firstInstanceTimeStamp, Iterable<InstanceIterable> instances, Iterable<InstanceIterable> exceptions)
+    {
+        this(new DateTime(timeZone, firstInstanceTimeStamp), new Composite(instances), new Composite(exceptions));
+    }
+
+
+    public RecurrenceSet(TimeZone timeZone, long firstInstanceTimeStamp, InstanceIterable instances, InstanceIterable exceptions)
+    {
+        this(new DateTime(timeZone, firstInstanceTimeStamp), instances, exceptions);
+    }
+
+
+    public RecurrenceSet(DateTime first, InstanceIterable instances)
+    {
+        this(first, instances, EmptyIterable.INSTANCE);
+    }
+
+
+    public RecurrenceSet(DateTime first, Iterable<InstanceIterable> instances)
+    {
+        this(first, new Composite(instances), EmptyIterable.INSTANCE);
+    }
+
+
+    public RecurrenceSet(DateTime first, Iterable<InstanceIterable> instances, Iterable<InstanceIterable> exceptions)
+    {
+        this(first, new Composite(instances), new Composite(exceptions));
+    }
+
+
+    public RecurrenceSet(DateTime first, InstanceIterable instances, InstanceIterable exceptions)
+    {
+        this.mFirst = first;
+        this.mInstances = instances;
+        this.mExceptions = exceptions;
+    }
+
+
+    @Override
+    public Iterator<DateTime> iterator()
+    {
+        EffectiveInstancesIterator rsi = new EffectiveInstancesIterator(mInstances.iterator(mFirst), mExceptions.iterator(mFirst));
+        return new Iterator<DateTime>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return rsi.hasNext();
+            }
+
+
+            @Override
+            public DateTime next()
+            {
+                DateTime result = new DateTime(mFirst.getTimeZone(), rsi.next());
+                if (mFirst.isAllDay())
+                {
+                    result = result.toAllDay();
+                }
+                return result;
+            }
+        };
+    }
+}

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/Composite.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/Composite.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.iterable.instanceiterable;
+
+import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.iterable.InstanceIterable;
+import org.dmfs.rfc5545.iterable.InstanceIterator;
+
+
+/**
+ * A composite {@link InstanceIterable} composed of other {@link InstanceIterable}s. This {@link InstanceIterator}
+ * returned by this class returns the instances of all given {@link InstanceIterable}s in chronological order.
+ */
+public final class Composite implements InstanceIterable
+{
+    private final InstanceIterable mDelegate;
+
+
+    public Composite(InstanceIterable... delegate)
+    {
+        this(new Seq<>(delegate));
+    }
+
+
+    public Composite(Iterable<InstanceIterable> delegate)
+    {
+        this(firstInstance -> new org.dmfs.rfc5545.iterable.instanceiterator.Composite(new Mapped<>(d -> d.iterator(firstInstance), delegate)));
+    }
+
+
+    private Composite(InstanceIterable delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public InstanceIterator iterator(DateTime firstInstance)
+    {
+        return mDelegate.iterator(firstInstance);
+    }
+}

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/EmptyIterable.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/EmptyIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Marten Gajda <marten@dmfs.org>
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,33 +15,25 @@
  * limitations under the License.
  */
 
-package org.dmfs.rfc5545.recurrenceset;
+package org.dmfs.rfc5545.iterable.instanceiterable;
 
-import java.util.NoSuchElementException;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.iterable.InstanceIterable;
+import org.dmfs.rfc5545.iterable.InstanceIterator;
+import org.dmfs.rfc5545.iterable.instanceiterator.EmptyIterator;
 
 
 /**
- * An {@link AbstractRecurrenceAdapter.InstanceIterator} without any instances.
+ * An {@link InstanceIterable} that doesn't have any instances.
  */
-@Deprecated
-public final class EmptyIterator implements AbstractRecurrenceAdapter.InstanceIterator
+public final class EmptyIterable implements InstanceIterable
 {
-    @Override
-    public boolean hasNext()
-    {
-        return false;
-    }
+    public static final InstanceIterable INSTANCE = new EmptyIterable();
 
 
     @Override
-    public long next()
+    public InstanceIterator iterator(DateTime firstInstance)
     {
-        throw new NoSuchElementException("No elements to iterate");
-    }
-
-
-    @Override
-    public void fastForward(long until)
-    {
+        return EmptyIterator.INSTANCE;
     }
 }

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/FastForwarded.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/FastForwarded.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.iterable.instanceiterable;
+
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.iterable.InstanceIterable;
+import org.dmfs.rfc5545.iterable.InstanceIterator;
+
+
+/**
+ * An {@link InstanceIterable} that fast forwards the iteration to a given instant. All instances prior to that instant will be skipped.
+ */
+public final class FastForwarded implements InstanceIterable
+{
+    private final long mTimeStamp;
+    private final InstanceIterable mDelegate;
+
+
+    public FastForwarded(DateTime fastForwardTo, InstanceIterable delegate)
+    {
+        this(fastForwardTo.getTimestamp(), delegate);
+    }
+
+
+    public FastForwarded(DateTime fastForwardTo, InstanceIterable... delegate)
+    {
+        this(fastForwardTo.getTimestamp(), new Composite(delegate));
+    }
+
+
+    public FastForwarded(DateTime fastForwardTo, Iterable<InstanceIterable> delegate)
+    {
+        this(fastForwardTo.getTimestamp(), new Composite(delegate));
+    }
+
+
+    public FastForwarded(long timeStamp, InstanceIterable delegate)
+    {
+        mTimeStamp = timeStamp;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public InstanceIterator iterator(DateTime firstInstance)
+    {
+        InstanceIterator iterator = mDelegate.iterator(firstInstance);
+        if (firstInstance.getTimestamp() < mTimeStamp)
+        {
+            iterator.fastForward(mTimeStamp);
+        }
+        return iterator;
+    }
+}

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/FirstAndRuleInstances.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/FirstAndRuleInstances.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.iterable.instanceiterable;
+
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.iterable.InstanceIterable;
+import org.dmfs.rfc5545.iterable.InstanceIterator;
+import org.dmfs.rfc5545.iterable.instanceiterator.Composite;
+import org.dmfs.rfc5545.iterable.instanceiterator.CountLimitedRecurrenceRuleIterator;
+import org.dmfs.rfc5545.recur.RecurrenceRule;
+import org.dmfs.rfc5545.recur.RecurrenceRuleIterator;
+
+
+/**
+ * Implements {@link InstanceIterable} for a {@link RecurrenceRule} that also returns any non-synchronized first instance.
+ */
+public final class FirstAndRuleInstances implements InstanceIterable
+{
+    /**
+     * The recurrence rule.
+     */
+    private final RecurrenceRule mRrule;
+
+
+    /**
+     * Create a new adapter for the given rule and start.
+     *
+     * @param rule
+     *     The recurrence rule to adapt to.
+     */
+    public FirstAndRuleInstances(RecurrenceRule rule)
+    {
+        mRrule = rule;
+    }
+
+
+    @Override
+    public InstanceIterator iterator(DateTime firstInstance)
+    {
+        RecurrenceRuleIterator ruleIterator = mRrule.iterator(firstInstance);
+        if (mRrule.getCount() != null && ruleIterator.peekMillis() != firstInstance.getTimestamp())
+        {
+            // we have a count limited rule and an unsynched start date
+            // since the start date counts as the first element, the RRULE iterator should return one less element.
+            return new Composite(
+                new InstanceList(new long[] { firstInstance.getTimestamp() }).iterator(firstInstance),
+                new CountLimitedRecurrenceRuleIterator(ruleIterator, mRrule.getCount() - 1));
+        }
+        return new InstanceIterator()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return ruleIterator.hasNext();
+            }
+
+
+            @Override
+            public long next()
+            {
+                return ruleIterator.nextMillis();
+            }
+
+
+            @Override
+            public void fastForward(long until)
+            {
+                ruleIterator.fastForward(until);
+            }
+        };
+    }
+}

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/InstanceList.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/InstanceList.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2013 Marten Gajda <marten@dmfs.org>
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,63 +13,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.dmfs.rfc5545.recurrenceset;
+package org.dmfs.rfc5545.iterable.instanceiterable;
 
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.calendarmetrics.CalendarMetrics;
+import org.dmfs.rfc5545.iterable.InstanceIterable;
+import org.dmfs.rfc5545.iterable.InstanceIterator;
 
 import java.util.Arrays;
 import java.util.TimeZone;
 
 
 /**
- * A concrete {@link AbstractRecurrenceAdapter} for lists of instances. You can provide the instances in a String or in an array of longs.
- *
- * @author Marten Gajda
+ * An {@link InstanceIterable} of a given list of instances.
  */
-@Deprecated
-public final class RecurrenceList extends AbstractRecurrenceAdapter
+public final class InstanceList implements InstanceIterable
 {
-    class InstanceIterator implements AbstractRecurrenceAdapter.InstanceIterator
-    {
-        private int mNext;
-
-
-        @Override
-        public boolean hasNext()
-        {
-            return mNext < mCount;
-        }
-
-
-        @Override
-        public long next()
-        {
-            if (mNext >= mCount)
-            {
-                throw new ArrayIndexOutOfBoundsException("No more instances to iterate.");
-            }
-            return mInstances[mNext++];
-        }
-
-
-        @Override
-        public void fastForward(long until)
-        {
-            int count = mCount;
-            int next = mNext;
-            long[] instances = mInstances;
-            while (next < count && instances[next] < until)
-            {
-                ++next;
-            }
-            mNext = next;
-        }
-    }
-
 
     /**
      * The instances to iterate.
@@ -85,11 +47,11 @@ public final class RecurrenceList extends AbstractRecurrenceAdapter
      * Create an adapter for the instances in <code>list</code>.
      *
      * @param list
-     *         A comma separated list of instances using the date-time format as defined in RFC 5545.
+     *     A comma separated list of instances using the date-time format as defined in RFC 5545.
      * @param timeZone
-     *         The time zone to apply to the instances.
+     *     The time zone to apply to the instances.
      */
-    public RecurrenceList(String list, TimeZone timeZone)
+    public InstanceList(String list, TimeZone timeZone)
     {
         this(DateTime.GREGORIAN_CALENDAR_SCALE, list, timeZone);
     }
@@ -99,13 +61,13 @@ public final class RecurrenceList extends AbstractRecurrenceAdapter
      * Create an adapter for the instances in <code>list</code>.
      *
      * @param calendarMetrics
-     *         The calendar scale to use.
+     *     The calendar scale to use.
      * @param list
-     *         A comma separated list of instances using the date-time format as defined in RFC 5545.
+     *     A comma separated list of instances using the date-time format as defined in RFC 5545.
      * @param timeZone
-     *         The time zone to apply to the instances.
+     *     The time zone to apply to the instances.
      */
-    public RecurrenceList(CalendarMetrics calendarMetrics, String list, TimeZone timeZone)
+    public InstanceList(CalendarMetrics calendarMetrics, String list, TimeZone timeZone)
     {
         if (list == null || list.length() == 0)
         {
@@ -133,9 +95,9 @@ public final class RecurrenceList extends AbstractRecurrenceAdapter
      * Create an adapter for the instances in <code>list</code>.
      *
      * @param instances
-     *         An array of instance time stamps in milliseconds.
+     *     An array of instance time stamps in milliseconds.
      */
-    public RecurrenceList(long[] instances)
+    public InstanceList(long[] instances)
     {
         mInstances = new long[instances.length];
         System.arraycopy(instances, 0, mInstances, 0, instances.length);
@@ -145,24 +107,41 @@ public final class RecurrenceList extends AbstractRecurrenceAdapter
 
 
     @Override
-    InstanceIterator getIterator(TimeZone timezone, long start)
+    public InstanceIterator iterator(DateTime firstInstance)
     {
-        return new InstanceIterator();
-    }
+        return new InstanceIterator()
+        {
+            private int mNext;
 
 
-    @Override
-    boolean isInfinite()
-    {
-        // the given lists are always finite
-        return false;
-    }
+            @Override
+            public boolean hasNext()
+            {
+                return mNext < mCount;
+            }
 
 
-    @Override
-    long getLastInstance(TimeZone timezone, long start)
-    {
-        long[] instances = mInstances;
-        return instances[instances.length - 1];
+            @Override
+            public long next()
+            {
+                if (mNext >= mCount)
+                {
+                    throw new ArrayIndexOutOfBoundsException("No more instances to iterate.");
+                }
+                return mInstances[mNext++];
+            }
+
+
+            @Override
+            public void fastForward(long until)
+            {
+                int next = mNext;
+                while (next < mCount && mInstances[next] < until)
+                {
+                    ++next;
+                }
+                mNext = next;
+            }
+        };
     }
 }

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/RuleInstances.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/RuleInstances.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.iterable.instanceiterable;
+
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.iterable.InstanceIterable;
+import org.dmfs.rfc5545.iterable.InstanceIterator;
+import org.dmfs.rfc5545.recur.RecurrenceRule;
+import org.dmfs.rfc5545.recur.RecurrenceRuleIterator;
+
+
+/**
+ * Implements {@link InstanceIterable} for a {@link RecurrenceRule}. That only iterates instances that match the {@link RecurrenceRule}.
+ * Any non-synchronized first instance is not returned.
+ */
+public final class RuleInstances implements InstanceIterable
+{
+
+    /**
+     * The recurrence rule.
+     */
+    private final RecurrenceRule mRrule;
+
+
+    /**
+     * Create a new adapter for the given rule and start.
+     *
+     * @param rule
+     *     The recurrence rule to adapt to.
+     */
+    public RuleInstances(RecurrenceRule rule)
+    {
+        mRrule = rule;
+    }
+
+
+    @Override
+    public InstanceIterator iterator(DateTime firstInstance)
+    {
+        RecurrenceRuleIterator iterator = mRrule.iterator(firstInstance);
+        return new InstanceIterator()
+        {
+            private final RecurrenceRuleIterator mIterator = iterator;
+
+
+            @Override
+            public boolean hasNext()
+            {
+                return mIterator.hasNext();
+            }
+
+
+            @Override
+            public long next()
+            {
+                return mIterator.nextMillis();
+            }
+
+
+            @Override
+            public void fastForward(long until)
+            {
+                mIterator.fastForward(until);
+            }
+        };
+    }
+}

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterator/Composite.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterator/Composite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Marten Gajda <marten@dmfs.org>
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +15,14 @@
  * limitations under the License.
  */
 
-package org.dmfs.rfc5545.recurrenceset;
+package org.dmfs.rfc5545.iterable.instanceiterator;
 
 import org.dmfs.jems2.comparator.By;
 import org.dmfs.jems2.iterable.Mapped;
+import org.dmfs.jems2.iterable.Seq;
 import org.dmfs.jems2.iterable.Sieved;
 import org.dmfs.jems2.single.Collected;
+import org.dmfs.rfc5545.iterable.InstanceIterator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,23 +31,27 @@ import java.util.NoSuchElementException;
 
 
 /**
- * An {@link AbstractRecurrenceAdapter.InstanceIterator} which iterates the elements of other {@link AbstractRecurrenceAdapter.InstanceIterator} in sorted
- * order.
+ * An {@link InstanceIterator} which iterates the elements of other {@link InstanceIterator} in chronological order.
  */
-@Deprecated
-public final class CompositeIterator implements AbstractRecurrenceAdapter.InstanceIterator
+public final class Composite implements InstanceIterator
 {
     private List<Helper> mHelpers;
 
 
-    public CompositeIterator(Iterable<AbstractRecurrenceAdapter.InstanceIterator> delegates)
+    public Composite(InstanceIterator... delegates)
+    {
+        this(new Seq<>(delegates));
+    }
+
+
+    public Composite(Iterable<InstanceIterator> delegates)
     {
         mHelpers = new Collected<>(
             ArrayList::new,
             new Mapped<>(
                 Helper::new,
                 new Sieved<>(
-                    AbstractRecurrenceAdapter.InstanceIterator::hasNext,
+                    InstanceIterator::hasNext,
                     delegates))).value();
         Collections.sort(mHelpers, new By<>(helper -> helper.nextValue));
 
@@ -172,16 +178,16 @@ public final class CompositeIterator implements AbstractRecurrenceAdapter.Instan
     private final static class Helper
     {
         private long nextValue;
-        private final AbstractRecurrenceAdapter.InstanceIterator iterator;
+        private final InstanceIterator iterator;
 
 
-        private Helper(AbstractRecurrenceAdapter.InstanceIterator iterator)
+        private Helper(InstanceIterator iterator)
         {
             this(iterator.next(), iterator);
         }
 
 
-        private Helper(long nextValue, AbstractRecurrenceAdapter.InstanceIterator iterator)
+        private Helper(long nextValue, InstanceIterator iterator)
         {
             this.nextValue = nextValue;
             this.iterator = iterator;

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterator/CountLimitedRecurrenceRuleIterator.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterator/CountLimitedRecurrenceRuleIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Marten Gajda <marten@dmfs.org>
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,20 +15,18 @@
  * limitations under the License.
  */
 
-package org.dmfs.rfc5545.recurrenceset;
+package org.dmfs.rfc5545.iterable.instanceiterator;
 
+import org.dmfs.rfc5545.iterable.InstanceIterator;
 import org.dmfs.rfc5545.recur.RecurrenceRuleIterator;
 
 import java.util.NoSuchElementException;
 
 
 /**
- * An {@link AbstractRecurrenceAdapter.InstanceIterator} which inserts a start instance.
- *
- * @author Marten Gajda
+ * An {@link InstanceIterator} which limits the number of iterated instances.
  */
-@Deprecated
-public final class CountLimitedRecurrenceRuleIterator implements AbstractRecurrenceAdapter.InstanceIterator
+public final class CountLimitedRecurrenceRuleIterator implements InstanceIterator
 {
     private final RecurrenceRuleIterator mDelegate;
     private int mRemaining;

--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterator/EmptyIterator.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterator/EmptyIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Marten Gajda <marten@dmfs.org>
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,17 +15,21 @@
  * limitations under the License.
  */
 
-package org.dmfs.rfc5545.recurrenceset;
+package org.dmfs.rfc5545.iterable.instanceiterator;
+
+import org.dmfs.rfc5545.iterable.InstanceIterator;
 
 import java.util.NoSuchElementException;
 
 
 /**
- * An {@link AbstractRecurrenceAdapter.InstanceIterator} without any instances.
+ * An {@link InstanceIterator} without any instances.
  */
-@Deprecated
-public final class EmptyIterator implements AbstractRecurrenceAdapter.InstanceIterator
+public final class EmptyIterator implements InstanceIterator
 {
+    public static final InstanceIterator INSTANCE = new EmptyIterator();
+
+
     @Override
     public boolean hasNext()
     {
@@ -43,5 +47,6 @@ public final class EmptyIterator implements AbstractRecurrenceAdapter.InstanceIt
     @Override
     public void fastForward(long until)
     {
+        /* nothing to do */
     }
 }

--- a/src/main/java/org/dmfs/rfc5545/recur/ByDayPrefixedFilter.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/ByDayPrefixedFilter.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.rfc5545.recur;
 
-import org.dmfs.jems.function.BiFunction;
+import org.dmfs.jems2.BiFunction;
 import org.dmfs.rfc5545.Instance;
 import org.dmfs.rfc5545.Weekday;
 import org.dmfs.rfc5545.calendarmetrics.CalendarMetrics;
@@ -36,16 +36,16 @@ final class ByDayPrefixedFilter implements ByFilter
     public enum Scope
     {
         MONTH(
-                (instance, metrics) ->
-                        (Instance.dayOfMonth(instance) - 1) / 7 + 1,
-                (instance, metrics) ->
-                        (Instance.dayOfMonth(instance) - metrics.getDaysPerPackedMonth(Instance.year(instance), Instance.month(instance))) / 7 - 1),
+            (instance, metrics) ->
+                (Instance.dayOfMonth(instance) - 1) / 7 + 1,
+            (instance, metrics) ->
+                (Instance.dayOfMonth(instance) - metrics.getDaysPerPackedMonth(Instance.year(instance), Instance.month(instance))) / 7 - 1),
         YEAR(
-                (instance, metrics) ->
-                        (metrics.getDayOfYear(Instance.year(instance), Instance.month(instance), Instance.dayOfMonth(instance)) - 1) / 7 + 1,
-                (instance, metrics) ->
-                        (metrics.getDayOfYear(Instance.year(instance), Instance.month(instance), Instance.dayOfMonth(instance))
-                                - metrics.getDaysPerYear(Instance.year(instance))) / 7 - 1);
+            (instance, metrics) ->
+                (metrics.getDayOfYear(Instance.year(instance), Instance.month(instance), Instance.dayOfMonth(instance)) - 1) / 7 + 1,
+            (instance, metrics) ->
+                (metrics.getDayOfYear(Instance.year(instance), Instance.month(instance), Instance.dayOfMonth(instance))
+                    - metrics.getDaysPerYear(Instance.year(instance))) / 7 - 1);
 
         private final BiFunction<Long, CalendarMetrics, Integer> mNthDay;
         private final BiFunction<Long, CalendarMetrics, Integer> mNthLastDay;
@@ -69,9 +69,9 @@ final class ByDayPrefixedFilter implements ByFilter
 
 
     public ByDayPrefixedFilter(
-            CalendarMetrics calendarMetrics,
-            Map<Weekday, Set<Integer>> prefixedWeekDays,
-            Scope scope)
+        CalendarMetrics calendarMetrics,
+        Map<Weekday, Set<Integer>> prefixedWeekDays,
+        Scope scope)
     {
         mCalendarMetrics = calendarMetrics;
         mPrefixedWeekDays = prefixedWeekDays;
@@ -83,11 +83,11 @@ final class ByDayPrefixedFilter implements ByFilter
     public boolean filter(long instance)
     {
         Set<Integer> prefixes = mPrefixedWeekDays.get(mWeekdayArray[mCalendarMetrics.getDayOfWeek(
-                Instance.year(instance),
-                Instance.month(instance),
-                Instance.dayOfMonth(instance))]);
+            Instance.year(instance),
+            Instance.month(instance),
+            Instance.dayOfMonth(instance))]);
         return prefixes == null
-                || (!prefixes.contains(mScope.mNthDay.value(instance, mCalendarMetrics))
-                && !prefixes.contains(mScope.mNthLastDay.value(instance, mCalendarMetrics)));
+            || (!prefixes.contains(mScope.mNthDay.value(instance, mCalendarMetrics))
+            && !prefixes.contains(mScope.mNthLastDay.value(instance, mCalendarMetrics)));
     }
 }

--- a/src/main/java/org/dmfs/rfc5545/recur/RecurrenceRule.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/RecurrenceRule.java
@@ -23,19 +23,8 @@ import org.dmfs.rfc5545.calendarmetrics.CalendarMetrics;
 import org.dmfs.rfc5545.calendarmetrics.CalendarMetrics.CalendarMetricsFactory;
 import org.dmfs.rfc5545.calendarmetrics.GregorianCalendarMetrics;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TimeZone;
 
 
 /**
@@ -124,107 +113,107 @@ public final class RecurrenceRule
          * Base frequency of the recurring instances. This value is mandatory in every recurrence rule. The value must be a {@link Freq}.
          */
         FREQ(new FreqConverter())
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        return new FreqIterator(rule, calendarMetrics, start);
-                    }
+                    return new FreqIterator(rule, calendarMetrics, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("FREQ doesn't have a filter.");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("FREQ doesn't have a filter.");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        // the frequency generator always expands
-                        return true;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // the frequency generator always expands
+                    return true;
+                }
+            },
 
         /**
          * The base interval of the recurring instances. If not specified the interval is <code>1</code>. The value must be a positive integer.
          */
         INTERVAL(new IntegerConverter(1, Integer.MAX_VALUE))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        throw new UnsupportedOperationException("INTERVAL doesn't have an iterator.");
-                    }
+                    throw new UnsupportedOperationException("INTERVAL doesn't have an iterator.");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("INTERVAL doesn't have a filter.");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("INTERVAL doesn't have a filter.");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        throw new UnsupportedOperationException("INTERVAL doesn't support expansion nor filtering");
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    throw new UnsupportedOperationException("INTERVAL doesn't support expansion nor filtering");
+                }
+            },
 
         /**
          * RSCALE defines the calendar scale to apply. It has been introduced in <a href="draft-daboo-icalendar-rscale-03">http://tools.ietf.org/html/draft-daboo-icalendar-rscale-03</a>
          */
         RSCALE(new RScaleConverter())
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    throws UnsupportedOperationException
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                            throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("RSCALE doesn't have an expander.");
-                    }
+                    throw new UnsupportedOperationException("RSCALE doesn't have an expander.");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("RSCALE doesn't have a filter.");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("RSCALE doesn't have a filter.");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        throw new UnsupportedOperationException("RSCALE doesn't support expansion nor filtering");
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    throw new UnsupportedOperationException("RSCALE doesn't support expansion nor filtering");
+                }
+            },
 
         /**
          * The start day of a week. The value must be a {@link Weekday}. This is relevant if any of {@link Part#BYDAY} or {@link Part#BYWEEKNO} are present.
          */
         WKST(new WeekdayConverter())
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        throw new UnsupportedOperationException("WKST doesn't have an iterator.");
-                    }
+                    throw new UnsupportedOperationException("WKST doesn't have an iterator.");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("WKST doesn't have a filter.");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("WKST doesn't have a filter.");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        throw new UnsupportedOperationException("WKST doesn't support expansion nor filtering.");
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    throw new UnsupportedOperationException("WKST doesn't support expansion nor filtering.");
+                }
+            },
 
         /**
          * A list of months that specify in which months the instances recur. The value is a list of non-zero integers. The actual values depend on the calendar
@@ -233,61 +222,61 @@ public final class RecurrenceRule
          * TODO: validate month numbers.
          */
         BYMONTH(new ListValueConverter<Integer>(new MonthConverter()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    return new ByMonthExpander(rule, previous, calendarMetrics, start);
+                }
+
+
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    if (rule.getFreq() == Freq.WEEKLY && (rule.hasPart(Part.BYDAY) || rule.hasPart(
+                        Part.BYMONTHDAY) || rule.hasPart(Part.BYYEARDAY)))
                     {
-                        return new ByMonthExpander(rule, previous, calendarMetrics, start);
+                        // the rule has a weekly scope and "By*day" filters, so we have to retain weeks that overlap this month
+                        return new ByMonthFilter(rule, calendarMetrics);
                     }
+                    return new TrivialByMonthFilter(rule);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        if (rule.getFreq() == Freq.WEEKLY && (rule.hasPart(Part.BYDAY) || rule.hasPart(
-                                Part.BYMONTHDAY) || rule.hasPart(Part.BYYEARDAY)))
-                        {
-                            // the rule has a weekly scope and "By*day" filters, so we have to retain weeks that overlap this month
-                            return new ByMonthFilter(rule, calendarMetrics);
-                        }
-                        return new TrivialByMonthFilter(rule);
-                    }
-
-
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return rule.getFreq() == Freq.YEARLY;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return rule.getFreq() == Freq.YEARLY;
+                }
+            },
 
         /**
          * The SKIP filter for months. This must not appear in an RRULE, any attempt to parse a value will fail. This is just an implementation helper.
          */
         _BYMONTHSKIP(ERROR_CONVERTER)
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    throws UnsupportedOperationException
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                            throws UnsupportedOperationException
-                    {
-                        return new ByMonthSkipFilter(rule, previous, calendarMetrics, start);
-                    }
+                    return new ByMonthSkipFilter(rule, previous, calendarMetrics, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("_BYMONTHSKIP doesn't support  filtering");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("_BYMONTHSKIP doesn't support  filtering");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return true;
-                    }
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return true;
+                }
 
-                },
+            },
 
         /**
          * A list of week numbers that specify in which weeks the instances recur.
@@ -295,47 +284,47 @@ public final class RecurrenceRule
          * TODO: validate week numbers
          */
         BYWEEKNO(new ListValueConverter<Integer>(new IntegerConverter(-53, 53).noZero()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
+                    ByExpander.Scope scope = rule.hasPart(Part.BYMONTH) ? ByExpander.Scope.MONTHLY : ByExpander.Scope.YEARLY;
+
+                    // allow overlapping weeks in MONTHLY scope and if any BY*DAY rule is present
+                    boolean allowOverlappingWeeks = scope == ByExpander.Scope.MONTHLY && (rule.hasPart(Part.BYDAY) || rule.hasPart(
+                        Part.BYMONTHDAY) || rule.hasPart(Part.BYYEARDAY));
+
+                    switch (scope)
                     {
-                        ByExpander.Scope scope = rule.hasPart(Part.BYMONTH) ? ByExpander.Scope.MONTHLY : ByExpander.Scope.YEARLY;
-
-                        // allow overlapping weeks in MONTHLY scope and if any BY*DAY rule is present
-                        boolean allowOverlappingWeeks = scope == ByExpander.Scope.MONTHLY && (rule.hasPart(Part.BYDAY) || rule.hasPart(
-                                Part.BYMONTHDAY) || rule.hasPart(Part.BYYEARDAY));
-
-                        switch (scope)
-                        {
-                            case MONTHLY:
-                                if (allowOverlappingWeeks)
-                                {
-                                    return new ByWeekNoMonthlyOverlapExpander(rule, previous, calendarTools, start);
-                                }
-                                return new ByWeekNoMonthlyExpander(rule, previous, calendarTools, start);
-                            case YEARLY:
-                                return new ByWeekNoYearlyExpander(rule, previous, calendarTools, start);
-                            default:
-                                throw new Error("Illegal scope");
-                        }
+                        case MONTHLY:
+                            if (allowOverlappingWeeks)
+                            {
+                                return new ByWeekNoMonthlyOverlapExpander(rule, previous, calendarTools, start);
+                            }
+                            return new ByWeekNoMonthlyExpander(rule, previous, calendarTools, start);
+                        case YEARLY:
+                            return new ByWeekNoYearlyExpander(rule, previous, calendarTools, start);
+                        default:
+                            throw new Error("Illegal scope");
                     }
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        // no filter defined
-                        return null;
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    // no filter defined
+                    return null;
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        // byweekno always expands
-                        return true;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // byweekno always expands
+                    return true;
+                }
+            },
 
         /**
          * A list of year days that specify on which year days the instances recur. The actual limits depend on the calendar scale and needs to be validated
@@ -344,31 +333,31 @@ public final class RecurrenceRule
          * TODO: validate year days
          */
         BYYEARDAY(new ListValueConverter<>(new IntegerConverter(-366, 366).noZero()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        // RFC 5545 only allows BYYEARDAY expansion for YEARLY rules
-                        // We'll expand it the same way for WEEKLY and MONTHLY though and filter afterwards for other frequencies if allowed by the mode
-                        return new ByYearDayYearlyExpander(rule, previous, calendarMetrics, start);
-                    }
+                    // RFC 5545 only allows BYYEARDAY expansion for YEARLY rules
+                    // We'll expand it the same way for WEEKLY and MONTHLY though and filter afterwards for other frequencies if allowed by the mode
+                    return new ByYearDayYearlyExpander(rule, previous, calendarMetrics, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new ByYearDayFilter(rule, calendarMetrics);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new ByYearDayFilter(rule, calendarMetrics);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        // expand in a yearly, monthly or weekly scope
-                        Freq freq = rule.getFreq();
-                        return freq == Freq.YEARLY || freq == Freq.MONTHLY || freq == Freq.WEEKLY;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // expand in a yearly, monthly or weekly scope
+                    Freq freq = rule.getFreq();
+                    return freq == Freq.YEARLY || freq == Freq.MONTHLY || freq == Freq.WEEKLY;
+                }
+            },
 
         /**
          * A list of month days on which the event recurs. Valid values are non-zero integers. The actual limits depend on the calendar scale and needs to be
@@ -377,378 +366,380 @@ public final class RecurrenceRule
          * TODO: validate month days
          */
         BYMONTHDAY(new ListValueConverter<Integer>(new IntegerConverter(-31, 31).noZero()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    ByExpander.Scope scope = rule.hasPart(Part.BYWEEKNO) || rule.getFreq() == Freq.WEEKLY ? (rule.hasPart(
+                        Part.BYMONTH) || rule.getFreq() == Freq.MONTHLY ? ByExpander.Scope.WEEKLY_AND_MONTHLY
+                        : ByExpander.Scope.WEEKLY)
+                        : ByExpander.Scope.MONTHLY;
+
+                    switch (scope)
                     {
-                        ByExpander.Scope scope = rule.hasPart(Part.BYWEEKNO) || rule.getFreq() == Freq.WEEKLY ? (rule.hasPart(
-                                Part.BYMONTH) || rule.getFreq() == Freq.MONTHLY ? ByExpander.Scope.WEEKLY_AND_MONTHLY
-                                : ByExpander.Scope.WEEKLY)
-                                : ByExpander.Scope.MONTHLY;
-
-                        switch (scope)
-                        {
-                            case MONTHLY:
-                                return new ByMonthDayMonthlyExpander(rule, previous, calendarMetrics, start);
-                            case WEEKLY:
-                                return new ByMonthDayWeeklyExpander(rule, previous, calendarMetrics, start);
-                            case WEEKLY_AND_MONTHLY:
-                                return new ByMonthDayWeeklyAndMonthlyExpander(rule, previous, calendarMetrics, start);
-                            default:
-                                throw new Error("Illegal Scope");
-                        }
+                        case MONTHLY:
+                            return new ByMonthDayMonthlyExpander(rule, previous, calendarMetrics, start);
+                        case WEEKLY:
+                            return new ByMonthDayWeeklyExpander(rule, previous, calendarMetrics, start);
+                        case WEEKLY_AND_MONTHLY:
+                            return new ByMonthDayWeeklyAndMonthlyExpander(rule, previous, calendarMetrics, start);
+                        default:
+                            throw new Error("Illegal Scope");
                     }
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new ByMonthDayFilter(rule, calendarMetrics);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new ByMonthDayFilter(rule, calendarMetrics);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        // expand in a yearly, monthly or weekly scope if byyearday is not present
-                        Freq freq = rule.getFreq();
-                        return (freq == Freq.YEARLY || freq == Freq.MONTHLY || freq == Freq.WEEKLY /* for RFC 2445 */) && !(rule
-                                .hasPart(Part.BYYEARDAY));
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // expand in a yearly, monthly or weekly scope if byyearday is not present
+                    Freq freq = rule.getFreq();
+                    return (freq == Freq.YEARLY || freq == Freq.MONTHLY || freq == Freq.WEEKLY /* for RFC 2445 */) && !(rule
+                        .hasPart(Part.BYYEARDAY));
+                }
+            },
 
         /**
          * The SKIP filter for monthdays. This must not appear in an RRULE, any attempt to parse a value will fail. This is just an implementation helper.
          */
         _BYMONTHDAYSKIP(ERROR_CONVERTER)
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    throws UnsupportedOperationException
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                            throws UnsupportedOperationException
-                    {
-                        return new ByMonthDaySkipFilter(rule, previous, calendarMetrics, start);
-                    }
+                    return new ByMonthDaySkipFilter(rule, previous, calendarMetrics, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("_BYMONTHDAYSKIP doesn't support filtering");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("_BYMONTHDAYSKIP doesn't support filtering");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return true;
-                    }
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return true;
+                }
 
-                },
+            },
 
         /**
          * A list of {@link WeekdayNum}s on which the event recurs.
          */
         BYDAY(new ListValueConverter<WeekdayNum>(new WeekdayNumConverter()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    boolean hasByMonth = rule.hasPart(Part.BYMONTH);
+                    Freq freq = rule.getFreq();
+
+                    ByExpander.Scope scope = rule.hasPart(
+                        Part.BYWEEKNO) || freq == Freq.WEEKLY ? (hasByMonth || freq == Freq.MONTHLY
+                        ? ByExpander.Scope.WEEKLY_AND_MONTHLY
+                        : ByExpander.Scope.WEEKLY)
+                        : (hasByMonth || freq == Freq.MONTHLY ? ByExpander.Scope.MONTHLY : ByExpander.Scope.YEARLY);
+
+                    switch (scope)
                     {
-                        boolean hasByMonth = rule.hasPart(Part.BYMONTH);
-                        Freq freq = rule.getFreq();
-
-                        ByExpander.Scope scope = rule.hasPart(
-                                Part.BYWEEKNO) || freq == Freq.WEEKLY ? (hasByMonth || freq == Freq.MONTHLY ? ByExpander.Scope.WEEKLY_AND_MONTHLY : ByExpander.Scope.WEEKLY)
-                                : (hasByMonth || freq == Freq.MONTHLY ? ByExpander.Scope.MONTHLY : ByExpander.Scope.YEARLY);
-
-                        switch (scope)
-                        {
-                            case WEEKLY:
-                                return new ByDayWeeklyExpander(rule, previous, calendarMetrics, start);
-                            case WEEKLY_AND_MONTHLY:
-                                return new ByDayWeeklyAndMonthlyExpander(rule, previous, calendarMetrics, start);
-                            case MONTHLY:
-                                return new ByDayMonthlyExpander(rule, previous, calendarMetrics, start);
-                            case YEARLY:
-                                return new ByDayYearlyExpander(rule, previous, calendarMetrics, start);
-                            default:
-                                throw new Error("Illegal scope");
-                        }
+                        case WEEKLY:
+                            return new ByDayWeeklyExpander(rule, previous, calendarMetrics, start);
+                        case WEEKLY_AND_MONTHLY:
+                            return new ByDayWeeklyAndMonthlyExpander(rule, previous, calendarMetrics, start);
+                        case MONTHLY:
+                            return new ByDayMonthlyExpander(rule, previous, calendarMetrics, start);
+                        case YEARLY:
+                            return new ByDayYearlyExpander(rule, previous, calendarMetrics, start);
+                        default:
+                            throw new Error("Illegal scope");
                     }
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    Freq freq = rule.getFreq();
+                    // TODO: this method looks ugly and can use some improvement
+                    // TODO: consider doing this separation at parsing time
+                    Set<Weekday> nonPrefixed = EnumSet.noneOf(Weekday.class);
+                    Map<Weekday, Set<Integer>> prefixed = new EnumMap<>(Weekday.class);
+
+                    for (WeekdayNum wn : rule.getByDayPart())
                     {
-                        Freq freq = rule.getFreq();
-                        // TODO: this method looks ugly and can use some improvement
-                        // TODO: consider doing this separation at parsing time
-                        Set<Weekday> nonPrefixed = EnumSet.noneOf(Weekday.class);
-                        Map<Weekday, Set<Integer>> prefixed = new EnumMap<>(Weekday.class);
-
-                        for (WeekdayNum wn : rule.getByDayPart())
+                        if (wn.pos == 0)
                         {
-                            if (wn.pos == 0)
+                            nonPrefixed.add(wn.weekday);
+                        }
+                        else
+                        {
+                            Set<Integer> prefixes = prefixed.get(wn.weekday);
+                            if (prefixes == null) // TODO use java 8 API, check Android support first
                             {
-                                nonPrefixed.add(wn.weekday);
+                                prefixes = new HashSet<>();
+                                prefixed.put(wn.weekday, prefixes);
                             }
-                            else
-                            {
-                                Set<Integer> prefixes = prefixed.get(wn.weekday);
-                                if (prefixes == null) // TODO use java 8 API, check Android support first
-                                {
-                                    prefixes = new HashSet<>();
-                                    prefixed.put(wn.weekday, prefixes);
-                                }
-                                prefixes.add(wn.pos);
-                            }
+                            prefixes.add(wn.pos);
                         }
-
-                        if (prefixed.isEmpty()
-                                || freq != Freq.YEARLY && freq != Freq.MONTHLY
-                                || freq == Freq.YEARLY && rule.hasPart(BYWEEKNO))
-                        {
-                            return new ByDayFilter(calendarMetrics, nonPrefixed);
-                        }
-                        ByFilter baseFilter = new ByDayPrefixedFilter(
-                                calendarMetrics,
-                                prefixed,
-                                freq == Freq.YEARLY && rule.getByPart(BYMONTH) == null ?
-                                        ByDayPrefixedFilter.Scope.YEAR :
-                                        ByDayPrefixedFilter.Scope.MONTH);
-
-                        if (nonPrefixed.isEmpty())
-                        {
-                            return baseFilter;
-                        }
-
-                        ByFilter nonPrefixFilter = new ByDayFilter(calendarMetrics, nonPrefixed);
-                        return instance -> nonPrefixFilter.filter(instance) && baseFilter.filter(instance);
                     }
 
-
-                    @Override
-                    boolean expands(RecurrenceRule rule)
+                    if (prefixed.isEmpty()
+                        || freq != Freq.YEARLY && freq != Freq.MONTHLY
+                        || freq == Freq.YEARLY && rule.hasPart(BYWEEKNO))
                     {
-                        // expands in a yearly or monthly scope if neither byyearday nor bymonthday are present and in a weekly scope.
-                        Freq freq = rule.getFreq();
-                        return ((freq == Freq.YEARLY || freq == Freq.MONTHLY) && !rule.hasPart(
-                                Part.BYYEARDAY) && !rule.hasPart(Part.BYMONTHDAY))
-                                || freq == Freq.WEEKLY;
+                        return new ByDayFilter(calendarMetrics, nonPrefixed);
                     }
-                },
+                    ByFilter baseFilter = new ByDayPrefixedFilter(
+                        calendarMetrics,
+                        prefixed,
+                        freq == Freq.YEARLY && rule.getByPart(BYMONTH) == null ?
+                            ByDayPrefixedFilter.Scope.YEAR :
+                            ByDayPrefixedFilter.Scope.MONTH);
+
+                    if (nonPrefixed.isEmpty())
+                    {
+                        return baseFilter;
+                    }
+
+                    ByFilter nonPrefixFilter = new ByDayFilter(calendarMetrics, nonPrefixed);
+                    return instance -> nonPrefixFilter.filter(instance) && baseFilter.filter(instance);
+                }
+
+
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // expands in a yearly or monthly scope if neither byyearday nor bymonthday are present and in a weekly scope.
+                    Freq freq = rule.getFreq();
+                    return ((freq == Freq.YEARLY || freq == Freq.MONTHLY) && !rule.hasPart(
+                        Part.BYYEARDAY) && !rule.hasPart(Part.BYMONTHDAY))
+                        || freq == Freq.WEEKLY;
+                }
+            },
 
         /**
          * A special BYMONTH filter for expander rewriting
          */
         _BYMONTH_FILTER(new ListValueConverter<>(new MonthConverter()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        throw new Error("Unexpected expander request");
-                    }
+                    throw new Error("Unexpected expander request");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new TrivialByMonthFilter(rule);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new TrivialByMonthFilter(rule);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return false;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return false;
+                }
+            },
 
         /**
          * A special BYWEEKNO filter for expander rewriting
          */
         _BYWEEKNO_FILTER(new ListValueConverter<>(new IntegerConverter(-53, 53).noZero()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
-                    {
-                        throw new Error("Unexpected Expansion request");
-                    }
+                    throw new Error("Unexpected Expansion request");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new ByWeekNoFilter(rule, calendarMetrics);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new ByWeekNoFilter(rule, calendarMetrics);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return false;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return false;
+                }
+            },
 
         /**
          * A special BYYEARDAY filter for expander rewriting
          */
         _BYYEARDAY_FILTER(new ListValueConverter<>(new IntegerConverter(-366, 366).noZero()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        throw new Error("Unexpected expander request");
-                    }
+                    throw new Error("Unexpected expander request");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new ByYearDayFilter(rule, calendarMetrics);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new ByYearDayFilter(rule, calendarMetrics);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return false;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return false;
+                }
+            },
 
         /**
          * A special BYMONTHDAY filter for expander rewriting
          */
         _BYMONTHDAY_FILTER(new ListValueConverter<>(new IntegerConverter(-31, 31).noZero()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        throw new Error("This filter does not expand.");
-                    }
+                    throw new Error("This filter does not expand.");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new ByMonthDayFilter(rule, calendarMetrics);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new ByMonthDayFilter(rule, calendarMetrics);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return false;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return false;
+                }
+            },
 
         /**
          * A special BYDAY filter for expander rewriting
          */
         _BYDAY_FILTER(new ListValueConverter<>(new WeekdayNumConverter()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        throw new Error("Unexpected expansion request");
-                    }
+                    throw new Error("Unexpected expansion request");
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return BYDAY.getFilter(rule, calendarMetrics);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return BYDAY.getFilter(rule, calendarMetrics);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return false;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return false;
+                }
+            },
 
         /**
          * The hours on which the event recurs. The value must be a list of integers in the range 0 to 23.
          */
         BYHOUR(new ListValueConverter<Integer>(new IntegerConverter(0, 23)))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
-                    {
-                        return new ByHourExpander(rule, previous, calendarTools, start);
-                    }
+                    return new ByHourExpander(rule, previous, calendarTools, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new ByHourFilter(rule);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new ByHourFilter(rule);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        // expands whenever the scope is larger than an hour
-                        Freq freq = rule.getFreq();
-                        return freq != Freq.SECONDLY && freq != Freq.MINUTELY && freq != Freq.HOURLY;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // expands whenever the scope is larger than an hour
+                    Freq freq = rule.getFreq();
+                    return freq != Freq.SECONDLY && freq != Freq.MINUTELY && freq != Freq.HOURLY;
+                }
+            },
 
         /**
          * The minutes on which the event recurs. The value must be a list of integers in the range 0 to 59.
          */
         BYMINUTE(new ListValueConverter<Integer>(new IntegerConverter(0, 59)))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
-                    {
-                        return new ByMinuteExpander(rule, previous, calendarTools, start);
-                    }
+                    return new ByMinuteExpander(rule, previous, calendarTools, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new ByMinuteFilter(rule);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new ByMinuteFilter(rule);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        // expands whenever the scope is larger than a minute
-                        Freq freq = rule.getFreq();
-                        return freq != Freq.SECONDLY && freq != Freq.MINUTELY;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // expands whenever the scope is larger than a minute
+                    Freq freq = rule.getFreq();
+                    return freq != Freq.SECONDLY && freq != Freq.MINUTELY;
+                }
+            },
 
         /**
          * The seconds on which the event recurs. The value must be a list of integers in the range 0 to 60.
          */
         BYSECOND(new ListValueConverter<Integer>(new IntegerConverter(0, 60)))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
-                    {
-                        return new BySecondExpander(rule, previous, calendarTools, start);
-                    }
+                    return new BySecondExpander(rule, previous, calendarTools, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        return new BySecondFilter(rule);
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    return new BySecondFilter(rule);
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        // expands whenever the scope is larger than a second
-                        return rule.getFreq() != Freq.SECONDLY;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    // expands whenever the scope is larger than a second
+                    return rule.getFreq() != Freq.SECONDLY;
+                }
+            },
 
         /**
          * SKIP defines how to handle instances that would fall on a leap day or leap month in a non-leap year. Legal values are defined in {@link Skip}. It has
@@ -757,68 +748,68 @@ public final class RecurrenceRule
          * Skipping is implemented by an expander because it might modify instances which is not supported by filters.
          */
         SKIP(new SkipValueConverter())
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    /*
+                     * The only case when we need the buffer is when rolling a month in a yearly rule forward, because the instance may end up in the next interval
+                     * (i.e. the next year). A leap month can not be the first month in a year, hence it's impossible that we roll a instance backwards to the last
+                     * year.
+                     *
+                     * Leap days may be rolled forward or backwards, but only to the first/last day of the next/previous month, which will be handled by the
+                     * SanityFilter.
+                     */
+                    if (rule.getFreq() == Freq.YEARLY && rule.getSkip() == Skip.FORWARD)
                     {
-                        /*
-                         * The only case when we need the buffer is when rolling a month in a yearly rule forward, because the instance may end up in the next interval
-                         * (i.e. the next year). A leap month can not be the first month in a year, hence it's impossible that we roll a instance backwards to the last
-                         * year.
-                         *
-                         * Leap days may be rolled forward or backwards, but only to the first/last day of the next/previous month, which will be handled by the
-                         * SanityFilter.
-                         */
-                        if (rule.getFreq() == Freq.YEARLY && rule.getSkip() == Skip.FORWARD)
-                        {
-                            return new SkipBuffer(rule, previous, calendarMetrics);
-                        }
-                        return null;
+                        return new SkipBuffer(rule, previous, calendarMetrics);
                     }
+                    return null;
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("SKIP doesn't support  filtering");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("SKIP doesn't support  filtering");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return true;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return true;
+                }
+            },
 
         /**
          * Filters all invalid dates. This must not appear in an RRULE, any attempt to parse a value will fail. This is just an implementation helper.
          */
         _SANITY_FILTER(ERROR_CONVERTER)
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
+                    throws UnsupportedOperationException
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                            throws UnsupportedOperationException
-                    {
-                        // note: despite it's name the SanityFilter is implemented as an expander
-                        return new SanityFilter(previous, calendarMetrics, start);
-                    }
+                    // note: despite it's name the SanityFilter is implemented as an expander
+                    return new SanityFilter(previous, calendarMetrics, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("_SANITY doesn't support filtering");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("_SANITY doesn't support filtering");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return true;
-                    }
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return true;
+                }
 
-                },
+            },
 
         /**
          * A list of set positions to consider when iterating the instances. The value is a list of integers. For now we accept any reasonable value.
@@ -826,83 +817,83 @@ public final class RecurrenceRule
          * TODO: validate the values. They should be within the limits of byyearday.
          */
         BYSETPOS(new ListValueConverter<Integer>(new IntegerConverter(-500, 500).noZero()))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
-                    {
-                        return new BySetPosFilter(rule, previous, start);
-                    }
+                    return new BySetPosFilter(rule, previous, start);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("BYSETPOS doesn't support  filtering");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("BYSETPOS doesn't support  filtering");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return true;
-                    }
-                },
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return true;
+                }
+            },
 
         /**
          * This part specifies the latest date of the last instance. The value is a {@link DateTime} in UTC or the local time zone. This part is mutually
          * exclusive with {@link #COUNT}. If neither {@link #UNTIL} nor {@link #COUNT} are specified the instances recur forever.
          */
         UNTIL(new DateTimeConverter())
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                    {
-                        return new UntilLimiter(rule, previous, calendarMetrics, startTimeZone);
-                    }
+                    return new UntilLimiter(rule, previous, calendarMetrics, startTimeZone);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("UNTIL doesn't support filtering");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("UNTIL doesn't support filtering");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return true;
-                    }
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return true;
+                }
 
-                },
+            },
 
         /**
          * This part specifies total number of instances. The value is a positive integer. This part is mutually exclusive with {@link #UNTIL}. If neither
          * {@link #COUNT} nor {@link #UNTIL} are specified the instances recur forever.
          */
         COUNT(new IntegerConverter(1, Integer.MAX_VALUE))
+            {
+                @Override
+                RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
                 {
-                    @Override
-                    RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarTools, long start, TimeZone startTimeZone)
-                    {
-                        return new CountLimiter(rule, previous);
-                    }
+                    return new CountLimiter(rule, previous);
+                }
 
 
-                    @Override
-                    ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
-                    {
-                        throw new UnsupportedOperationException("COUNT doesn't support  filtering");
-                    }
+                @Override
+                ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException
+                {
+                    throw new UnsupportedOperationException("COUNT doesn't support  filtering");
+                }
 
 
-                    @Override
-                    boolean expands(RecurrenceRule rule)
-                    {
-                        return true;
-                    }
+                @Override
+                boolean expands(RecurrenceRule rule)
+                {
+                    return true;
+                }
 
-                };
+            };
 
         /**
          * A {@link ValueConverter} that can parse and serialize the value for a specific part. The generic type depends on the actual part.
@@ -914,7 +905,7 @@ public final class RecurrenceRule
          * Private constructor.
          *
          * @param converter
-         *         The {@link ValueConverter} that knows how to parse and serialize this part.
+         *     The {@link ValueConverter} that knows how to parse and serialize this part.
          */
         private Part(ValueConverter<?> converter)
         {
@@ -928,37 +919,37 @@ public final class RecurrenceRule
          * </p>
          *
          * @param rule
-         *         The rule to iterate.
+         *     The rule to iterate.
          * @param previous
-         *         The previous element in the filter chain.
+         *     The previous element in the filter chain.
          * @param calendarMetrics
-         *         The {@link CalendarMetrics} to use.
+         *     The {@link CalendarMetrics} to use.
          * @param start
-         *         The first instance of the event.
+         *     The first instance of the event.
          * @param startTimeZone
-         *         The {@link TimeZone} this event is in.
+         *     The {@link TimeZone} this event is in.
          *
          * @return The {@link RuleIterator} for this part.
          *
          * @throws UnsupportedOperationException
-         *         If this part does not have a {@link RuleIterator}.
+         *     If this part does not have a {@link RuleIterator}.
          */
         abstract RuleIterator getExpander(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, long start, TimeZone startTimeZone)
-                throws UnsupportedOperationException;
+            throws UnsupportedOperationException;
 
         /**
          * Return a {@link ByFilter}. <p> <strong>Note:</strong> {@link #FREQ}, {@link #INTERVAL}, {@link #RSCALE} and {@link #WKST} don't support this method
          * and throw an {@link UnsupportedOperationException}. </p>
          *
          * @param rule
-         *         The rule to iterate.
+         *     The rule to iterate.
          * @param calendarMetrics
-         *         The {@link CalendarMetrics} to use.
+         *     The {@link CalendarMetrics} to use.
          *
          * @return The {@link RuleIterator} for this part or <code>null</code> if the give rule doesn't need this part.
          *
          * @throws UnsupportedOperationException
-         *         If this part does not have a {@link ByFilter}.
+         *     If this part does not have a {@link ByFilter}.
          */
         abstract ByFilter getFilter(RecurrenceRule rule, CalendarMetrics calendarMetrics) throws UnsupportedOperationException;
 
@@ -966,7 +957,7 @@ public final class RecurrenceRule
          * Returns whether this part expands instances or not.
          *
          * @param rule
-         *         The rule this part belongs to.
+         *     The rule this part belongs to.
          *
          * @return <code>true</code> if this rule expands instances, <code>false</code> if it filters instances for the given rule.
          */
@@ -981,35 +972,35 @@ public final class RecurrenceRule
     static
     {
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYYEARDAY, Part.BYMONTHDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTHDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTHDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYYEARDAY, Part.BYMONTHDAY, Part.BYDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYWEEKNO, Part.BYYEARDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYWEEKNO, Part.BYYEARDAY, Part.BYDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER, Part._BYDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER, Part._BYDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYWEEKNO, Part.BYYEARDAY, Part.BYMONTHDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYWEEKNO, Part.BYYEARDAY, Part.BYMONTHDAY, Part.BYDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
 
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYYEARDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYYEARDAY, Part.BYDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYYEARDAY, Part.BYMONTHDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYMONTHDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYMONTHDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYYEARDAY, Part.BYMONTHDAY, Part.BYDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
 
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYWEEKNO, Part.BYYEARDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYWEEKNO, Part.BYYEARDAY, Part.BYDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER, Part._BYDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER, Part._BYDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYWEEKNO, Part.BYYEARDAY, Part.BYMONTHDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER));
         YEAR_REWRITE_MAP.put(EnumSet.of(Part.BYMONTH, Part.BYWEEKNO, Part.BYYEARDAY, Part.BYMONTHDAY, Part.BYDAY),
-                EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
+            EnumSet.of(Part.BYYEARDAY, Part._BYMONTH_FILTER, Part._BYWEEKNO_FILTER, Part._BYMONTHDAY_FILTER, Part._BYDAY_FILTER));
     }
 
 
@@ -1052,9 +1043,9 @@ public final class RecurrenceRule
          * TODO: update range check
          *
          * @param pos
-         *         The position of the weekday in the Interval or <code>0</code> for every occurrence of the weekday.
+         *     The position of the weekday in the Interval or <code>0</code> for every occurrence of the weekday.
          * @param weekday
-         *         The {@link Weekday}.
+         *     The {@link Weekday}.
          */
         public WeekdayNum(int pos, Weekday weekday)
         {
@@ -1072,14 +1063,14 @@ public final class RecurrenceRule
          * definition in RFC 2445).
          *
          * @param value
-         *         The weekdaynum String to parse.
+         *     The weekdaynum String to parse.
          * @param tolerant
-         *         Set to <code>true</code> to be tolerant and accept values outside of the allowed range.
+         *     Set to <code>true</code> to be tolerant and accept values outside of the allowed range.
          *
          * @return A new {@link WeekdayNum} instance.
          *
          * @throws InvalidRecurrenceRuleException
-         *         If the weekdaynum string is invalid.
+         *     If the weekdaynum string is invalid.
          */
         public static WeekdayNum valueOf(String value, boolean tolerant) throws InvalidRecurrenceRuleException
         {
@@ -1113,12 +1104,12 @@ public final class RecurrenceRule
          * definition in RFC 2445). In contrast to {@link #valueOf(String, boolean)} this method is always strict and throws on every invalid value.
          *
          * @param value
-         *         The weekdaynum String to parse.
+         *     The weekdaynum String to parse.
          *
          * @return A new {@link WeekdayNum} instance.
          *
          * @throws InvalidRecurrenceRuleException
-         *         If the weekdaynum string is invalid.
+         *     If the weekdaynum string is invalid.
          */
         public static WeekdayNum valueOf(String value) throws InvalidRecurrenceRuleException
         {
@@ -1192,10 +1183,10 @@ public final class RecurrenceRule
      * parts to produce a valid recurrence rule.
      *
      * @param recur
-     *         A recurrence rule string as defined in <a href="http://tools.ietf.org/html/rfc5545#section-3.3.10">RFC 5545</a>.
+     *     A recurrence rule string as defined in <a href="http://tools.ietf.org/html/rfc5545#section-3.3.10">RFC 5545</a>.
      *
      * @throws InvalidRecurrenceRuleException
-     *         If an unrecoverable error occurs when parsing the rule (like FREQ is missing, or mutually exclusive parts have been found).
+     *     If an unrecoverable error occurs when parsing the rule (like FREQ is missing, or mutually exclusive parts have been found).
      */
     public RecurrenceRule(String recur) throws InvalidRecurrenceRuleException
     {
@@ -1207,13 +1198,13 @@ public final class RecurrenceRule
      * Create a new recurrence rule from String using a custom {@link RfcMode}.
      *
      * @param recur
-     *         A recurrence rule string as defined in <a href="http://tools.ietf.org/html/rfc5545#section-3.3.10">RFC 5545</a>.
+     *     A recurrence rule string as defined in <a href="http://tools.ietf.org/html/rfc5545#section-3.3.10">RFC 5545</a>.
      * @param mode
-     *         A {@link RfcMode} to change the parsing behaviour in case of errors.
+     *     A {@link RfcMode} to change the parsing behaviour in case of errors.
      *
      * @throws InvalidRecurrenceRuleException
-     *         If the rule is invalid with respect to the chosen mode or if an unrecoverable error occurs when parsing the rule (like FREQ is missing, or
-     *         mutually exclusive parts have been found).
+     *     If the rule is invalid with respect to the chosen mode or if an unrecoverable error occurs when parsing the rule (like FREQ is missing, or
+     *     mutually exclusive parts have been found).
      */
     public RecurrenceRule(String recur, RfcMode mode) throws InvalidRecurrenceRuleException
     {
@@ -1227,7 +1218,7 @@ public final class RecurrenceRule
      * comply with RFC 5545, otherwise an exception is thrown.
      *
      * @param freq
-     *         The {@link Freq} values that specified the base frequency for this rule.
+     *     The {@link Freq} values that specified the base frequency for this rule.
      */
     public RecurrenceRule(Freq freq)
     {
@@ -1239,9 +1230,9 @@ public final class RecurrenceRule
      * Create a new recurrence rule with the given base frequency using a custom {@link RfcMode}.
      *
      * @param freq
-     *         The {@link Freq} values that specified the base frequency for this rule.
+     *     The {@link Freq} values that specified the base frequency for this rule.
      * @param mode
-     *         A {@link RfcMode} to change the behavior in case of errors.
+     *     A {@link RfcMode} to change the behavior in case of errors.
      */
     public RecurrenceRule(Freq freq, RfcMode mode)
     {
@@ -1256,9 +1247,7 @@ public final class RecurrenceRule
      * 2445</a> but not in <a href="http://tools.ietf.org/html/rfc5545#section-3.3.10">RFC 5545</a>).
      *
      * @param recur
-     *         A recurrence rule string.
-     *
-     * @throws InvalidRecurrenceRuleException
+     *     A recurrence rule string.
      */
     private void parseString(String recur) throws InvalidRecurrenceRuleException
     {
@@ -1285,7 +1274,7 @@ public final class RecurrenceRule
         {
             // in RFC2445 rules must start with "FREQ=" !
             throw new InvalidRecurrenceRuleException(
-                    "RFC 2445 requires FREQ to be the first part of the rule: " + recur);
+                "RFC 2445 requires FREQ to be the first part of the rule: " + recur);
         }
 
         CalendarMetrics calScale = mCalendarMetrics;
@@ -1308,7 +1297,7 @@ public final class RecurrenceRule
                     {
                         String value = keyvalue.substring(equals + 1);
                         rScale = (CalendarMetrics) Part.RSCALE.converter.parse(value, calScale, null /* that's what we're trying to find out */,
-                                relaxed);
+                            relaxed);
                         partMap.put(Part.RSCALE, rScale);
                         break;
                     }
@@ -1380,7 +1369,7 @@ public final class RecurrenceRule
                 {
                     Object partValue = part.converter.parse(value, calScale, rScale, relaxed);
                     if (partValue != null && (part != Part.INTERVAL || !ONE.equals(
-                            partValue) /* do not store intervals with value 1 */))
+                        partValue) /* do not store intervals with value 1 */))
                     {
                         partMap.put(part, partValue);
                     }
@@ -1438,10 +1427,10 @@ public final class RecurrenceRule
      * Checks for invalid rules when a numeric value is set in BYDAY. Depending on the mode either an exception is thrown or the BYDAY rule is simply dropped.
      *
      * @param freq
-     *         The {@link Freq} specified in the rule.
+     *     The {@link Freq} specified in the rule.
      *
      * @throws InvalidRecurrenceRuleException
-     *         if the mode is set to RFC5545_STRICT and an invalid rule is detected.
+     *     if the mode is set to RFC5545_STRICT and an invalid rule is detected.
      */
     private void checkForInvalidNumericInByDay(Freq freq) throws InvalidRecurrenceRuleException
     {
@@ -1464,7 +1453,7 @@ public final class RecurrenceRule
                         if (mode == RfcMode.RFC5545_STRICT)
                         {
                             final String errMsg = "The BYDAY rule part must not be specified with a numeric value when the FREQ "
-                                    + "rule part is not set to MONTHLY or YEARLY.";
+                                + "rule part is not set to MONTHLY or YEARLY.";
                             throw new InvalidRecurrenceRuleException(errMsg);
                         }
                         else
@@ -1481,7 +1470,7 @@ public final class RecurrenceRule
                         if (mode == RfcMode.RFC5545_STRICT)
                         {
                             final String errMsg = "The BYDAY rule part must not be specified with a numeric value with"
-                                    + " the FREQ rule part set to YEARLY when BYWEEKNO is set";
+                                + " the FREQ rule part set to YEARLY when BYWEEKNO is set";
                             throw new InvalidRecurrenceRuleException(errMsg);
                         }
                         else
@@ -1499,7 +1488,7 @@ public final class RecurrenceRule
      * Validate this rule.
      *
      * @throws InvalidRecurrenceRuleException
-     *         if the rule is not valid with respect to the current {@link #mode}.
+     *     if the rule is not valid with respect to the current {@link #mode}.
      */
     private void validate() throws InvalidRecurrenceRuleException
     {
@@ -1550,10 +1539,10 @@ public final class RecurrenceRule
         {
             // in RFC 5545 BYYEARDAY does not support DAILY, WEEKLY and MONTHLY rules
             if ((freq == Freq.DAILY || freq == Freq.WEEKLY || freq == Freq.MONTHLY) && partMap.containsKey(
-                    Part.BYYEARDAY))
+                Part.BYYEARDAY))
             {
                 throw new InvalidRecurrenceRuleException(
-                        "In RFC 5545, BYYEARDAY is not allowed in DAILY, WEEKLY or MONTHLY rules");
+                    "In RFC 5545, BYYEARDAY is not allowed in DAILY, WEEKLY or MONTHLY rules");
             }
 
             // in RFC 5545 BYMONTHAY must not be used in WEEKLY rules
@@ -1571,16 +1560,16 @@ public final class RecurrenceRule
         if (partMap.containsKey(Part.BYSETPOS))
         {
             if (!partMap.containsKey(Part.BYDAY) && !partMap.containsKey(Part.BYMONTHDAY) && !partMap.containsKey(
-                    Part.BYMONTH)
-                    && !partMap.containsKey(Part.BYHOUR) && !partMap.containsKey(Part.BYMINUTE) && !partMap.containsKey(
-                    Part.BYSECOND)
-                    && !partMap.containsKey(Part.BYWEEKNO) && !partMap.containsKey(Part.BYYEARDAY))
+                Part.BYMONTH)
+                && !partMap.containsKey(Part.BYHOUR) && !partMap.containsKey(Part.BYMINUTE) && !partMap.containsKey(
+                Part.BYSECOND)
+                && !partMap.containsKey(Part.BYWEEKNO) && !partMap.containsKey(Part.BYYEARDAY))
             {
                 if (strict)
                 {
                     // we're in strict mode => throw exception
                     throw new InvalidRecurrenceRuleException(
-                            "BYSETPOS must only be used in conjunction with another BYxxx rule.");
+                        "BYSETPOS must only be used in conjunction with another BYxxx rule.");
                 }
                 else
                 {
@@ -1600,12 +1589,12 @@ public final class RecurrenceRule
      * Validate if adding a specific list part would result in a valid rule.
      *
      * @param part
-     *         The part to be added.
+     *     The part to be added.
      * @param value
-     *         The value of this part.
+     *     The value of this part.
      *
      * @throws InvalidRecurrenceRuleException
-     *         if the rule is not valid with respect to the current {@link #mode}.
+     *     if the rule is not valid with respect to the current {@link #mode}.
      */
     private void validate(Part part, List<Integer> value) throws InvalidRecurrenceRuleException
     {
@@ -1623,7 +1612,7 @@ public final class RecurrenceRule
             if ((freq == Freq.DAILY || freq == Freq.WEEKLY || freq == Freq.MONTHLY) && part == Part.BYYEARDAY)
             {
                 throw new InvalidRecurrenceRuleException(
-                        "In RFC 5545, BYYEARDAY is not allowed in DAILY, WEEKLY or MONTHLY rules");
+                    "In RFC 5545, BYYEARDAY is not allowed in DAILY, WEEKLY or MONTHLY rules");
             }
 
             // in RFC 5545 BYMONTHAY must not be used in WEEKLY rules
@@ -1650,10 +1639,10 @@ public final class RecurrenceRule
      * Set the base frequency of this recurrence rule. <p> TODO: check if the rule is still valid afterwards (honor the silent parameter) </p>
      *
      * @param freq
-     *         The new {@link Freq} value of this rule.
+     *     The new {@link Freq} value of this rule.
      * @param silent
-     *         <code>true</code> to drop {@link Part}s that are no longer valid with the new frequency silently, <code>false</code> to throw an exception in
-     *         that case.
+     *     <code>true</code> to drop {@link Part}s that are no longer valid with the new frequency silently, <code>false</code> to throw an exception in
+     *     that case.
      */
     public void setFreq(Freq freq, boolean silent)
     {
@@ -1683,7 +1672,7 @@ public final class RecurrenceRule
      * calendar.
      *
      * @param skip
-     *         The new {@link Skip} value of this rule, <code>null</code> and {@link Skip#OMIT} will remove the SKIP part, the later one is the default anyway.
+     *     The new {@link Skip} value of this rule, <code>null</code> and {@link Skip#OMIT} will remove the SKIP part, the later one is the default anyway.
      */
     public void setSkip(Skip skip)
     {
@@ -1733,10 +1722,10 @@ public final class RecurrenceRule
      * default value anyway.
      *
      * @param interval
-     *         The new interval of this rule.
+     *     The new interval of this rule.
      *
      * @throws IllegalArgumentException
-     *         if interval is not a positive integer value.
+     *     if interval is not a positive integer value.
      */
     public void setInterval(int interval)
     {
@@ -1773,7 +1762,7 @@ public final class RecurrenceRule
      * not floating it's automatically converted to UTC.
      *
      * @param until
-     *         The UNTIL part of this rule or <code>null</code> to let the instances recur forever.
+     *     The UNTIL part of this rule or <code>null</code> to let the instances recur forever.
      */
     public void setUntil(DateTime until)
     {
@@ -1785,7 +1774,7 @@ public final class RecurrenceRule
         else
         {
             if ((!until.isFloating() && !DateTime.UTC.equals(until.getTimeZone())) || !mCalendarMetrics.equals(
-                    until.getCalendarMetrics()))
+                until.getCalendarMetrics()))
             {
                 mParts.put(Part.UNTIL, new DateTime(mCalendarMetrics, DateTime.UTC, until.getTimestamp()));
             }
@@ -1813,7 +1802,7 @@ public final class RecurrenceRule
      * Set the number of instances in the recurrence set. This will remove any UNTIL rule if present.
      *
      * @param count
-     *         The number if instances.
+     *     The number if instances.
      */
     public void setCount(int count)
     {
@@ -1837,7 +1826,7 @@ public final class RecurrenceRule
      * Checks if a specific part is present in this rule.
      *
      * @param part
-     *         The part if interest.
+     *     The part if interest.
      *
      * @return <code>true</code> if this rule has this part, <code>false</code> otherwise
      */
@@ -1854,7 +1843,7 @@ public final class RecurrenceRule
      * </p>
      *
      * @param part
-     *         The by-rule to return.
+     *     The by-rule to return.
      *
      * @return A list of integer values.
      */
@@ -1884,12 +1873,12 @@ public final class RecurrenceRule
      * #setByDayPart(List)}. </p>
      *
      * @param part
-     *         The by-rule to set.
+     *     The by-rule to set.
      * @param value
-     *         A list of integers that specify the rule or <code>null</code> (or an empty list) to remove the part.
+     *     A list of integers that specify the rule or <code>null</code> (or an empty list) to remove the part.
      *
      * @throws InvalidRecurrenceRuleException
-     *         if the list would become invalid by adding this part (this respects the current {@link RfcMode}.
+     *     if the list would become invalid by adding this part (this respects the current {@link RfcMode}.
      */
     public void setByPart(Part part, List<Integer> value) throws InvalidRecurrenceRuleException
     {
@@ -1925,12 +1914,12 @@ public final class RecurrenceRule
      * #setByDayPart(List)}. </p>
      *
      * @param part
-     *         The by-rule to set.
+     *     The by-rule to set.
      * @param values
-     *         Integers that specify the rule or <code>null</code> (or an empty list) to remove the part.
+     *     Integers that specify the rule or <code>null</code> (or an empty list) to remove the part.
      *
      * @throws InvalidRecurrenceRuleException
-     *         if the list would become invalid by adding this part (this respects the current {@link RfcMode}.
+     *     if the list would become invalid by adding this part (this respects the current {@link RfcMode}.
      */
     public void setByPart(Part part, Integer... values) throws InvalidRecurrenceRuleException
     {
@@ -1949,7 +1938,7 @@ public final class RecurrenceRule
      * Set the BYDAY part of this rule.
      *
      * @param value
-     *         A {@link List} of {@link WeekdayNum}s or <code>null</code> or an empty List to remove the part
+     *     A {@link List} of {@link WeekdayNum}s or <code>null</code> or an empty List to remove the part
      */
     public void setByDayPart(List<WeekdayNum> value)
     {
@@ -1991,7 +1980,7 @@ public final class RecurrenceRule
      * important for rules having a BYWEEKNO or BYDAY part.
      *
      * @param wkst
-     *         The start of the week to use when calculating the instances.
+     *     The start of the week to use when calculating the instances.
      */
     public void setWeekStart(Weekday wkst)
     {
@@ -2004,10 +1993,10 @@ public final class RecurrenceRule
      * that's the default value. This value is important for rules having a BYWEEKNO or BYDAY part.
      *
      * @param wkst
-     *         The start of the week to use when calculating the instances.
+     *     The start of the week to use when calculating the instances.
      * @param keepWkStMo
-     *         set to <code>true</code> to keep the WKST field if the value is {@link Weekday#MO}. Since Monday is the default adding it is not necessary, but
-     *         some implementations might be broken and use a different weekstart if it's not explicitly specified.
+     *     set to <code>true</code> to keep the WKST field if the value is {@link Weekday#MO}. Since Monday is the default adding it is not necessary, but
+     *     some implementations might be broken and use a different weekstart if it's not explicitly specified.
      */
     public void setWeekStart(Weekday wkst, boolean keepWkStMo)
     {
@@ -2029,12 +2018,12 @@ public final class RecurrenceRule
      * in RFC 2445 mode will override any existing x-part of the same name. </p>
      *
      * @param xname
-     *         The name of the x-part. Must be a valid identifier.
+     *     The name of the x-part. Must be a valid identifier.
      * @param value
-     *         The value of the x-part. Must be a valid name.
+     *     The value of the x-part. Must be a valid name.
      *
      * @throws UnsupportedOperationException
-     *         if {@link #mode} is set to {@link RfcMode#RFC5545_STRICT}.
+     *     if {@link #mode} is set to {@link RfcMode#RFC5545_STRICT}.
      */
     public void setXPart(String xname, String value)
     {
@@ -2078,7 +2067,7 @@ public final class RecurrenceRule
      * {@link #mode} equals {@link RfcMode#RFC5545_LAX} or {@link RfcMode#RFC5545_STRICT}.
      *
      * @param xname
-     *         The name of the x-part to check for.
+     *     The name of the x-part to check for.
      *
      * @return <code>true</code> if the part is present, <code>false</code> otherwise.
      */
@@ -2098,7 +2087,7 @@ public final class RecurrenceRule
      * RfcMode#RFC5545_LAX} or {@link RfcMode#RFC5545_STRICT}.
      *
      * @param xname
-     *         The name of the x-part to return.
+     *     The name of the x-part to return.
      *
      * @return The value of the x-part or <code>null</code>.
      */
@@ -2119,9 +2108,9 @@ public final class RecurrenceRule
      * value, you have to provide <code>null</code> as the timezone. </p>
      *
      * @param start
-     *         The time of the first instance in milliseconds since the epoch.
+     *     The time of the first instance in milliseconds since the epoch.
      * @param timezone
-     *         The {@link TimeZone} of the first instance or <code>null</code> for floating times.
+     *     The {@link TimeZone} of the first instance or <code>null</code> for floating times.
      *
      * @return A {@link RecurrenceRuleIterator}.
      */
@@ -2143,7 +2132,7 @@ public final class RecurrenceRule
      * floating time then start must be floating as well and vice versa. The same applies if the UNTIL value is an all-day value </p>
      *
      * @param start
-     *         The first instance.
+     *     The first instance.
      *
      * @return A {@link RuleIterator}.
      */
@@ -2155,12 +2144,12 @@ public final class RecurrenceRule
             if (until.isAllDay() != start.isAllDay())
             {
                 throw new IllegalArgumentException(
-                        "using allday start times with non-allday until values (and vice versa) is not allowed");
+                    "using allday start times with non-allday until values (and vice versa) is not allowed");
             }
             if (until.isFloating() != start.isFloating())
             {
                 throw new IllegalArgumentException(
-                        "using floating start times with absolute until values (and vice versa) is not allowed");
+                    "using floating start times with absolute until values (and vice versa) is not allowed");
             }
         }
 
@@ -2171,12 +2160,12 @@ public final class RecurrenceRule
         }
 
         // make sure we convert start to the rscale calendar metrics if they don't equal
-        long startInstance = !rScaleCalendarMetrics.scaleEquals(start.getCalendarMetrics()) ? new DateTime(
-                rScaleCalendarMetrics, start).getInstance() : start
-                .getInstance();
-
-        RuleIterator iterator = null;
+        long startInstance = !rScaleCalendarMetrics.scaleEquals(start.getCalendarMetrics())
+            ? new DateTime(rScaleCalendarMetrics, start).getInstance()
+            : start.getInstance();
         TimeZone startTimeZone = start.isFloating() ? null : start.getTimeZone();
+
+        RuleIterator iterator = Part.FREQ.getExpander(this, null, rScaleCalendarMetrics, startInstance, startTimeZone);
 
         // add SanityFilter if not present yet
         mParts.put(Part._SANITY_FILTER, null);
@@ -2194,17 +2183,15 @@ public final class RecurrenceRule
             }
         }
 
-        // since FREQ is the first part anyway we don't have to create it separately
         for (Part p : parts)
         {
             // add a filter for each rule part
-            if (p != Part.INTERVAL && p != Part.WKST && p != Part.RSCALE)
+            if (p != Part.FREQ && p != Part.INTERVAL && p != Part.WKST && p != Part.RSCALE)
             {
                 if (p.expands(this))
                 {
                     // if a part returns null for the expander just skip it
-                    RuleIterator newIterator = p.getExpander(this, iterator, rScaleCalendarMetrics, startInstance,
-                            startTimeZone);
+                    RuleIterator newIterator = p.getExpander(this, iterator, rScaleCalendarMetrics, startInstance, startTimeZone);
                     iterator = newIterator == null ? iterator : newIterator;
                 }
                 else
@@ -2275,7 +2262,7 @@ public final class RecurrenceRule
      * Abstract class to parse and serialize a specific part of a RRULE.
      *
      * @param <T>
-     *         The type returned by the parser and expected by the serializer.
+     *     The type returned by the parser and expected by the serializer.
      *
      * @author Marten Gajda <marten@dmfs.org>
      */
@@ -2285,14 +2272,14 @@ public final class RecurrenceRule
          * Parses a string for a specific value <T>.
          *
          * @param value
-         *         The string representation of the value.
+         *     The string representation of the value.
          * @param tolerant
-         *         <code>true</code> to ignore any errors if possible
+         *     <code>true</code> to ignore any errors if possible
          *
          * @return An instance of <T> with the correct value.
          *
          * @throws InvalidRecurrenceRuleException
-         *         if the value is invalid.
+         *     if the value is invalid.
          */
         public abstract T parse(String value, CalendarMetrics calScale, CalendarMetrics rScale, boolean tolerant) throws InvalidRecurrenceRuleException;
 
@@ -2302,9 +2289,9 @@ public final class RecurrenceRule
          * the value. </p>
          *
          * @param out
-         *         The {@link StringBuilder} to write to.
+         *     The {@link StringBuilder} to write to.
          * @param value
-         *         The value to serialize.
+         *     The value to serialize.
          */
         public void serialize(StringBuilder out, Object value, CalendarMetrics rScale)
         {
@@ -2317,7 +2304,7 @@ public final class RecurrenceRule
      * Generic converter for comma separated list values.
      *
      * @param <T>
-     *         The type of the list elements.
+     *     The type of the list elements.
      *
      * @author Marten Gajda <marten@dmfs.org>
      */
@@ -2430,9 +2417,9 @@ public final class RecurrenceRule
          * Creates a new converter for integer lists.
          *
          * @param min
-         *         The lowest allowed value.
+         *     The lowest allowed value.
          * @param max
-         *         The highest allowed value.
+         *     The highest allowed value.
          */
         public IntegerConverter(int min, int max)
         {

--- a/src/main/java/org/dmfs/rfc5545/recur/RecurrenceRule.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/RecurrenceRule.java
@@ -401,8 +401,7 @@ public final class RecurrenceRule
                 {
                     // expand in a yearly, monthly or weekly scope if byyearday is not present
                     Freq freq = rule.getFreq();
-                    return (freq == Freq.YEARLY || freq == Freq.MONTHLY || freq == Freq.WEEKLY /* for RFC 2445 */) && !(rule
-                        .hasPart(Part.BYYEARDAY));
+                    return (freq == Freq.YEARLY || freq == Freq.MONTHLY || freq == Freq.WEEKLY /* for RFC 2445 */) && !rule.hasPart(Part.BYYEARDAY);
                 }
             },
 
@@ -495,8 +494,8 @@ public final class RecurrenceRule
                     }
 
                     if (prefixed.isEmpty()
-                        || freq != Freq.YEARLY && freq != Freq.MONTHLY
-                        || freq == Freq.YEARLY && rule.hasPart(BYWEEKNO))
+                        || (freq != Freq.YEARLY && freq != Freq.MONTHLY)
+                        || (freq == Freq.YEARLY && rule.hasPart(BYWEEKNO)))
                     {
                         return new ByDayFilter(calendarMetrics, nonPrefixed);
                     }

--- a/src/main/java/org/dmfs/rfc5545/recur/UntilLimiter.java
+++ b/src/main/java/org/dmfs/rfc5545/recur/UntilLimiter.java
@@ -44,8 +44,6 @@ final class UntilLimiter extends Limiter
      *         The {@link RecurrenceRule} to filter.
      * @param previous
      *         The previous filter instance.
-     * @param start
-     *         The first instance. This is used to determine if the iterated instances are floating or not.
      */
     public UntilLimiter(RecurrenceRule rule, RuleIterator previous, CalendarMetrics calendarMetrics, TimeZone startTimezone)
     {

--- a/src/main/java/org/dmfs/rfc5545/recurrenceset/AbstractRecurrenceAdapter.java
+++ b/src/main/java/org/dmfs/rfc5545/recurrenceset/AbstractRecurrenceAdapter.java
@@ -26,6 +26,7 @@ import java.util.TimeZone;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public abstract class AbstractRecurrenceAdapter
 {
 

--- a/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceRuleAdapter.java
+++ b/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceRuleAdapter.java
@@ -28,6 +28,7 @@ import java.util.TimeZone;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public final class RecurrenceRuleAdapter extends AbstractRecurrenceAdapter
 {
 

--- a/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSet.java
+++ b/src/main/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSet.java
@@ -32,6 +32,7 @@ import java.util.TimeZone;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public class RecurrenceSet
 {
 

--- a/src/test/java/org/dmfs/rfc5545/iterable/RecurrenceSetTest.java
+++ b/src/test/java/org/dmfs/rfc5545/iterable/RecurrenceSetTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.rfc5545.iterable;
+
+import org.dmfs.jems2.iterable.Seq;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.Duration;
+import org.dmfs.rfc5545.iterable.instanceiterable.FastForwarded;
+import org.dmfs.rfc5545.iterable.instanceiterable.FirstAndRuleInstances;
+import org.dmfs.rfc5545.iterable.instanceiterable.InstanceList;
+import org.dmfs.rfc5545.iterable.instanceiterable.RuleInstances;
+import org.dmfs.rfc5545.recur.InvalidRecurrenceRuleException;
+import org.dmfs.rfc5545.recur.RecurrenceRule;
+import org.junit.jupiter.api.Test;
+
+import java.util.TimeZone;
+
+import static org.dmfs.jems2.hamcrest.matchers.iterable.IterableMatcher.iteratesTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+class RecurrenceSetTest
+{
+    @Test
+    void testWithFullSet() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO;COUNT=5"))),
+            iteratesTo(
+                DateTime.parse("20220101"),
+                DateTime.parse("20220103"),
+                DateTime.parse("20220110"),
+                DateTime.parse("20220117"),
+                DateTime.parse("20220124")
+            ));
+    }
+
+
+    @Test
+    void testWithStrictSet() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new RuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO;COUNT=5"))),
+            iteratesTo(
+                DateTime.parse("20220103"),
+                DateTime.parse("20220110"),
+                DateTime.parse("20220117"),
+                DateTime.parse("20220124"),
+                DateTime.parse("20220131")
+            ));
+    }
+
+
+    @Test
+    void testWithMultipleSets() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new Seq<>(
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO;COUNT=5")),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=TU;UNTIL=20220125")))),
+            iteratesTo(
+                DateTime.parse("20220101"),
+                DateTime.parse("20220103"),
+                DateTime.parse("20220104"),
+                DateTime.parse("20220110"),
+                DateTime.parse("20220111"),
+                DateTime.parse("20220117"),
+                DateTime.parse("20220118"),
+                DateTime.parse("20220124"),
+                DateTime.parse("20220125")
+            ));
+    }
+
+
+    @Test
+    void testWithExceptions() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new Seq<>(
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO;COUNT=5")),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=TU;UNTIL=20220125"))
+                ),
+                new Seq<>(new InstanceList("20220110,20220118", DateTime.UTC))),
+            iteratesTo(
+                DateTime.parse("20220101"),
+                DateTime.parse("20220103"),
+                DateTime.parse("20220104"),
+                DateTime.parse("20220111"),
+                DateTime.parse("20220117"),
+                DateTime.parse("20220124"),
+                DateTime.parse("20220125")
+            ));
+    }
+
+
+    @Test
+    void testWithFastForward() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new FastForwarded(DateTime.parse("20220111"),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO;COUNT=5")),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=TU;UNTIL=20220125"))
+                ),
+                new InstanceList("20220110,20220118", DateTime.UTC)),
+            iteratesTo(
+                DateTime.parse("20220111"),
+                DateTime.parse("20220117"),
+                DateTime.parse("20220124"),
+                DateTime.parse("20220125")
+            ));
+    }
+
+
+    @Test
+    void testWithTimeStamp() throws InvalidRecurrenceRuleException
+    {
+        DateTime start = DateTime.parse(TimeZone.getTimeZone("Europe/Berlin"), "20220101T120000");
+        assertThat(new RecurrenceSet(start.getTimeZone(), start.getTimestamp(),
+                new FastForwarded(start.addDuration(Duration.parse("P10D")),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO;COUNT=5")),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=TU;UNTIL=20220125T110000Z"))
+                ),
+                new InstanceList("20220110T120000,20220118T120000", start.getTimeZone())),
+            iteratesTo(
+                DateTime.parse(start.getTimeZone(), "20220111T120000"),
+                DateTime.parse(start.getTimeZone(), "20220117T120000"),
+                DateTime.parse(start.getTimeZone(), "20220124T120000"),
+                DateTime.parse(start.getTimeZone(), "20220125T120000")
+            ));
+    }
+
+
+    @Test
+    void testWithDuplicates() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new FastForwarded(DateTime.parse("20220111"),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO;COUNT=5")),
+                    new FirstAndRuleInstances(new RecurrenceRule("FREQ=WEEKLY;BYDAY=MO,TU;UNTIL=20220125"))
+                ),
+                new InstanceList("20220110,20220118", DateTime.UTC)),
+            iteratesTo(
+                DateTime.parse("20220111"),
+                DateTime.parse("20220117"),
+                DateTime.parse("20220124"),
+                DateTime.parse("20220125")
+            ));
+    }
+}

--- a/src/test/java/org/dmfs/rfc5545/recur/InvalidRuleTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/InvalidRuleTest.java
@@ -1,12 +1,14 @@
 package org.dmfs.rfc5545.recur;
 
-import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.dmfs.rfc5545.recur.RecurrenceRule.RfcMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**

--- a/src/test/java/org/dmfs/rfc5545/recur/LongArrayTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/LongArrayTest.java
@@ -1,84 +1,84 @@
 package org.dmfs.rfc5545.recur;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
 public class LongArrayTest
 {
 
-	@Test
-	public void testDeduplicate()
-	{
-		LongArray l1 = new LongArray();
-		l1.add(1);
-		l1.add(2);
-		l1.add(3);
-		l1.add(4);
-		l1.add(5);
-		l1.add(6);
+    @Test
+    public void testDeduplicate()
+    {
+        LongArray l1 = new LongArray();
+        l1.add(1);
+        l1.add(2);
+        l1.add(3);
+        l1.add(4);
+        l1.add(5);
+        l1.add(6);
 
-		l1.deduplicate();
-		assertEquals(6, l1.size());
-		assertEquals(1, l1.next());
-		assertEquals(2, l1.next());
-		assertEquals(3, l1.next());
-		assertEquals(4, l1.next());
-		assertEquals(5, l1.next());
-		assertEquals(6, l1.next());
-		assertFalse(l1.hasNext());
+        l1.deduplicate();
+        assertEquals(6, l1.size());
+        assertEquals(1, l1.next());
+        assertEquals(2, l1.next());
+        assertEquals(3, l1.next());
+        assertEquals(4, l1.next());
+        assertEquals(5, l1.next());
+        assertEquals(6, l1.next());
+        assertFalse(l1.hasNext());
 
-		LongArray l2 = new LongArray();
-		l2.add(1);
-		l2.add(1);
-		l2.add(1);
-		l2.add(1);
-		l2.add(2);
-		l2.add(2);
-		l2.add(2);
-		l2.add(2);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(3);
-		l2.add(4);
-		l2.add(5);
-		l2.add(5);
-		l2.add(5);
-		l2.add(5);
-		l2.add(5);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
-		l2.add(6);
+        LongArray l2 = new LongArray();
+        l2.add(1);
+        l2.add(1);
+        l2.add(1);
+        l2.add(1);
+        l2.add(2);
+        l2.add(2);
+        l2.add(2);
+        l2.add(2);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(3);
+        l2.add(4);
+        l2.add(5);
+        l2.add(5);
+        l2.add(5);
+        l2.add(5);
+        l2.add(5);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
+        l2.add(6);
 
-		l2.deduplicate();
-		assertEquals(6, l2.size());
-		assertEquals(1, l2.next());
-		assertEquals(2, l2.next());
-		assertEquals(3, l2.next());
-		assertEquals(4, l2.next());
-		assertEquals(5, l2.next());
-		assertEquals(6, l2.next());
-		assertFalse(l2.hasNext());
+        l2.deduplicate();
+        assertEquals(6, l2.size());
+        assertEquals(1, l2.next());
+        assertEquals(2, l2.next());
+        assertEquals(3, l2.next());
+        assertEquals(4, l2.next());
+        assertEquals(5, l2.next());
+        assertEquals(6, l2.next());
+        assertFalse(l2.hasNext());
 
-	}
+    }
 
 }

--- a/src/test/java/org/dmfs/rfc5545/recur/RScaleTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RScaleTest.java
@@ -18,18 +18,15 @@
 package org.dmfs.rfc5545.recur;
 
 import org.dmfs.rfc5545.DateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.are;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.instances;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.startingWith;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.validRule;
+import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.DayOfMonthMatcher.onDayOfMonth;
 import static org.dmfs.rfc5545.hamcrest.datetime.DayOfYearMatcher.onDayOfYear;
 import static org.dmfs.rfc5545.hamcrest.datetime.MonthMatcher.inMonth;
 import static org.dmfs.rfc5545.hamcrest.datetime.WeekOfYearMatcher.inWeekOfYear;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 
 /**
@@ -41,38 +38,38 @@ public final class RScaleTest
     public void testByYearDaySkip() throws InvalidRecurrenceRuleException
     {
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=366"),
-                is(validRule(DateTime.parse("20121231"),
-                        instances(are(onDayOfMonth(31), inMonth(12))),
-                        startingWith("20121231", "20161231", "20201231"))));
+            is(validRule(DateTime.parse("20121231"),
+                instances(are(onDayOfMonth(31), inMonth(12))),
+                startingWith("20121231", "20161231", "20201231"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=366;SKIP=OMIT"),
-                is(validRule(DateTime.parse("20121231"),
-                        instances(are(onDayOfMonth(31), inMonth(12))),
-                        startingWith("20121231", "20161231", "20201231"))));
+            is(validRule(DateTime.parse("20121231"),
+                instances(are(onDayOfMonth(31), inMonth(12))),
+                startingWith("20121231", "20161231", "20201231"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=366;SKIP=FORWARD"),
-                is(validRule(DateTime.parse("20121231"),
-                        instances(are(onDayOfMonth(1, 31), inMonth(1, 12), onDayOfYear(1, 366))),
-                        startingWith("20121231", "20140101", "20150101", "20160101", "20161231", "20180101", "20190101", "20200101", "20201231"))));
+            is(validRule(DateTime.parse("20121231"),
+                instances(are(onDayOfMonth(1, 31), inMonth(1, 12), onDayOfYear(1, 366))),
+                startingWith("20121231", "20140101", "20150101", "20160101", "20161231", "20180101", "20190101", "20200101", "20201231"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=366;SKIP=BACKWARD"),
-                is(validRule(DateTime.parse("20121231"),
-                        instances(are(onDayOfMonth(31), inMonth(12))),
-                        startingWith("20121231", "20131231", "20141231", "20151231", "20161231", "20171231", "20181231", "20191231", "20201231"))));
+            is(validRule(DateTime.parse("20121231"),
+                instances(are(onDayOfMonth(31), inMonth(12))),
+                startingWith("20121231", "20131231", "20141231", "20151231", "20161231", "20171231", "20181231", "20191231", "20201231"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=-366"),
-                is(validRule(DateTime.parse("20120101"),
-                        instances(are(onDayOfMonth(1), inMonth(1))),
-                        startingWith("20120101", "20160101", "20200101"))));
+            is(validRule(DateTime.parse("20120101"),
+                instances(are(onDayOfMonth(1), inMonth(1))),
+                startingWith("20120101", "20160101", "20200101"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=-366;SKIP=OMIT"),
-                is(validRule(DateTime.parse("20120101"),
-                        instances(are(onDayOfMonth(1), inMonth(1))),
-                        startingWith("20120101", "20160101", "20200101"))));
+            is(validRule(DateTime.parse("20120101"),
+                instances(are(onDayOfMonth(1), inMonth(1))),
+                startingWith("20120101", "20160101", "20200101"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=-366;SKIP=FORWARD"),
-                is(validRule(DateTime.parse("20120101"),
-                        instances(are(onDayOfMonth(1), inMonth(1), onDayOfYear(1))),
-                        startingWith("20120101", "20130101", "20140101", "20150101", "20160101", "20170101", "20180101", "20190101", "20200101"))));
+            is(validRule(DateTime.parse("20120101"),
+                instances(are(onDayOfMonth(1), inMonth(1), onDayOfYear(1))),
+                startingWith("20120101", "20130101", "20140101", "20150101", "20160101", "20170101", "20180101", "20190101", "20200101"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYYEARDAY=-366;SKIP=BACKWARD"),
-                is(validRule(DateTime.parse("20120101"),
-                        instances(are(onDayOfMonth(1, 31), inMonth(1, 12))),
-                        startingWith("20120101", "20121231", "20131231", "20141231", "20160101", "20161231", "20171231", "20181231", "20200101"))));
+            is(validRule(DateTime.parse("20120101"),
+                instances(are(onDayOfMonth(1, 31), inMonth(1, 12))),
+                startingWith("20120101", "20121231", "20131231", "20141231", "20160101", "20161231", "20171231", "20181231", "20200101"))));
     }
 
 
@@ -80,41 +77,41 @@ public final class RScaleTest
     public void testByWeekNoSkip() throws InvalidRecurrenceRuleException
     {
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=53"),
-                is(validRule(DateTime.parse("20151229"),
-                        instances(are(onDayOfMonth(28, 29), inMonth(12), inWeekOfYear(53))),
-                        startingWith("20151229", "20201229", "20261229"))));
+            is(validRule(DateTime.parse("20151229"),
+                instances(are(onDayOfMonth(28, 29), inMonth(12), inWeekOfYear(53))),
+                startingWith("20151229", "20201229", "20261229"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=53;SKIP=OMIT"),
-                is(validRule(DateTime.parse("20151229"),
-                        instances(are(onDayOfMonth(28, 29), inMonth(12), inWeekOfYear(53))),
-                        startingWith("20151229", "20201229", "20261229"))));
+            is(validRule(DateTime.parse("20151229"),
+                instances(are(onDayOfMonth(28, 29), inMonth(12), inWeekOfYear(53))),
+                startingWith("20151229", "20201229", "20261229"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=53;SKIP=FORWARD"),
-                is(validRule(DateTime.parse("20151229"),
-                        instances(are(onDayOfMonth(1, 28, 29), inMonth(1, 12), inWeekOfYear(1, 52, 53))),
-                        startingWith("20151229", "20170101", "20180101", "20190101", "20200101", "20201229", "20220101", "20230101", "20240101", "20250101",
-                                "20260101", "20261229"))));
+            is(validRule(DateTime.parse("20151229"),
+                instances(are(onDayOfMonth(1, 28, 29), inMonth(1, 12), inWeekOfYear(1, 52, 53))),
+                startingWith("20151229", "20170101", "20180101", "20190101", "20200101", "20201229", "20220101", "20230101", "20240101", "20250101",
+                    "20260101", "20261229"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=53;SKIP=BACKWARD"),
-                is(validRule(DateTime.parse("20151229"),
-                        instances(are(onDayOfMonth(28, 29, 31), inMonth(1, 12), inWeekOfYear(1, 52, 53))),
-                        startingWith("20151229", "20161231", "20171231", "20181231", "20191231", "20201229", "20211231", "20221231", "20231231", "20241231",
-                                "20251231", "20261229"))));
+            is(validRule(DateTime.parse("20151229"),
+                instances(are(onDayOfMonth(28, 29, 31), inMonth(1, 12), inWeekOfYear(1, 52, 53))),
+                startingWith("20151229", "20161231", "20171231", "20181231", "20191231", "20201229", "20211231", "20221231", "20231231", "20241231",
+                    "20251231", "20261229"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=-53"),
-                is(validRule(DateTime.parse("20150103"),
-                        instances(are(onDayOfMonth(3, 4), inMonth(1), inWeekOfYear(1))),
-                        startingWith("20150103", "20200104", "20260103"))));
+            is(validRule(DateTime.parse("20150103"),
+                instances(are(onDayOfMonth(3, 4), inMonth(1), inWeekOfYear(1))),
+                startingWith("20150103", "20200104", "20260103"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=-53;SKIP=OMIT"),
-                is(validRule(DateTime.parse("20150103"),
-                        instances(are(onDayOfMonth(3, 4), inMonth(1), inWeekOfYear(1))),
-                        startingWith("20150103", "20200104", "20260103"))));
+            is(validRule(DateTime.parse("20150103"),
+                instances(are(onDayOfMonth(3, 4), inMonth(1), inWeekOfYear(1))),
+                startingWith("20150103", "20200104", "20260103"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=-53;SKIP=FORWARD"),
-                is(validRule(DateTime.parse("20150103"),
-                        instances(are(onDayOfMonth(1, 3, 4), inMonth(1), inWeekOfYear(1, 52, 53))),
-                        startingWith("20150103", "20160101", "20170101", "20180101", "20190101", "20200104", "20210101", "20220101", "20230101", "20240101",
-                                "20250101", "20260103"))));
+            is(validRule(DateTime.parse("20150103"),
+                instances(are(onDayOfMonth(1, 3, 4), inMonth(1), inWeekOfYear(1, 52, 53))),
+                startingWith("20150103", "20160101", "20170101", "20180101", "20190101", "20200104", "20210101", "20220101", "20230101", "20240101",
+                    "20250101", "20260103"))));
         assertThat(new RecurrenceRule("FREQ=YEARLY;RSCALE=GREGORIAN;BYWEEKNO=-53;SKIP=BACKWARD"),
-                is(validRule(DateTime.parse("20150103"),
-                        instances(are(onDayOfMonth(3, 4, 31), inMonth(1, 12), inWeekOfYear(1, 52, 53))),
-                        startingWith("20150103", "20151231", "20161231", "20171231", "20181231", "20200104", "20201231", "20211231", "20221231", "20231231",
-                                "20241231", "20260103"))));
+            is(validRule(DateTime.parse("20150103"),
+                instances(are(onDayOfMonth(3, 4, 31), inMonth(1, 12), inWeekOfYear(1, 52, 53))),
+                startingWith("20150103", "20151231", "20161231", "20171231", "20181231", "20200104", "20201231", "20211231", "20221231", "20231231",
+                    "20241231", "20260103"))));
     }
 }

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceEquivalenceTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceEquivalenceTest.java
@@ -2,15 +2,11 @@ package org.dmfs.rfc5545.recur;
 
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.recur.RecurrenceRule.RfcMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -19,154 +15,154 @@ import static org.junit.Assert.assertTrue;
 public class RecurrenceEquivalenceTest
 {
 
-	private final static Set<Unit> mRules = new HashSet<Unit>();
-	public static final RfcMode defaultMode = RfcMode.RFC5545_LAX;
-	public static final String defaultStartDate = "20120101";
-
-	private class Unit
-	{
-		private Set<TestRule> rules;
+    private final static Set<Unit> mRules = new HashSet<Unit>();
+    public static final RfcMode defaultMode = RfcMode.RFC5545_LAX;
+    public static final String defaultStartDate = "20120101";
 
 
-		/**
-		 *
-		 * @param rules
-		 *            {@link TestRule}s that should be compared
-		 */
-		public Unit(TestRule... rules)
-		{
-			this.rules = new HashSet<TestRule>();
-			this.rules.addAll(Arrays.asList(rules));
-			for (TestRule recRule : this.rules)
-			{
-				if (recRule.start == null)
-				{
-					recRule.setStart(defaultStartDate);
-				}
-			}
-		}
+    private class Unit
+    {
+        private Set<TestRule> rules;
 
 
-		/**
-		 * Compares the instances of the given {@link TestRule}'s.
-		 *
-		 * @return <code>True</code> if the instances match, otherwise <code>false</code>.
-		 */
-		public boolean compareRules()
-		{
-			for (List<DateTime> instancesA : expandAll())
-			{
-				for (List<DateTime> instancesB : expandAll())
-				{
-					if (!instancesA.equals(instancesB))
-					{
-						return false;
-					}
-				}
-			}
-			return true;
-		}
+        /**
+         * @param rules
+         *     {@link TestRule}s that should be compared
+         */
+        public Unit(TestRule... rules)
+        {
+            this.rules = new HashSet<TestRule>();
+            this.rules.addAll(Arrays.asList(rules));
+            for (TestRule recRule : this.rules)
+            {
+                if (recRule.start == null)
+                {
+                    recRule.setStart(defaultStartDate);
+                }
+            }
+        }
 
 
-		private List<List<DateTime>> expandAll()
-		{
-			List<List<DateTime>> instanceCollection = new ArrayList<List<DateTime>>();
-			for (TestRule recRule : rules)
-			{
-				instanceCollection.add(expandRule(recRule));
-			}
-			return instanceCollection;
-		}
+        /**
+         * Compares the instances of the given {@link TestRule}'s.
+         *
+         * @return <code>True</code> if the instances match, otherwise <code>false</code>.
+         */
+        public boolean compareRules()
+        {
+            for (List<DateTime> instancesA : expandAll())
+            {
+                for (List<DateTime> instancesB : expandAll())
+                {
+                    if (!instancesA.equals(instancesB))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
 
 
-		private List<DateTime> expandRule(TestRule rule)
-		{
-			try
-			{
-				RecurrenceRule r = new RecurrenceRule(rule.rule, rule.mode);
-				RecurrenceRuleIterator it = r.iterator(rule.start);
-				List<DateTime> instances = new ArrayList<DateTime>(1000);
-				int count = 0;
-				while (it.hasNext())
-				{
-					DateTime instance = it.nextDateTime();
-					instances.add(instance);
-					count++;
-					if (count == 10/* RecurrenceIteratorTest.MAX_ITERATIONS */)
-					{
-						break;
-					}
-				}
-				return instances;
-			}
-			catch (Exception e)
-			{
-				e.printStackTrace();
-				throw new IllegalArgumentException("Invalid testrule: " + rule.rule);
-			}
-		}
+        private List<List<DateTime>> expandAll()
+        {
+            List<List<DateTime>> instanceCollection = new ArrayList<List<DateTime>>();
+            for (TestRule recRule : rules)
+            {
+                instanceCollection.add(expandRule(recRule));
+            }
+            return instanceCollection;
+        }
 
 
-		public Unit setStart(String start)
-		{
-			for (TestRule recRule : rules)
-			{
-				recRule.setStart(start);
-			}
-			return this;
-		}
-	}
+        private List<DateTime> expandRule(TestRule rule)
+        {
+            try
+            {
+                RecurrenceRule r = new RecurrenceRule(rule.rule, rule.mode);
+                RecurrenceRuleIterator it = r.iterator(rule.start);
+                List<DateTime> instances = new ArrayList<DateTime>(1000);
+                int count = 0;
+                while (it.hasNext())
+                {
+                    DateTime instance = it.nextDateTime();
+                    instances.add(instance);
+                    count++;
+                    if (count == 10/* RecurrenceIteratorTest.MAX_ITERATIONS */)
+                    {
+                        break;
+                    }
+                }
+                return instances;
+            }
+            catch (Exception e)
+            {
+                e.printStackTrace();
+                throw new IllegalArgumentException("Invalid testrule: " + rule.rule);
+            }
+        }
 
 
-	@Test
-	public void testEquivalence()
-	{
-		addRules();
-		for (Unit ruleUnit : mRules)
-		{
-			assertTrue(ruleUnit.compareRules());
-		}
-	}
+        public Unit setStart(String start)
+        {
+            for (TestRule recRule : rules)
+            {
+                recRule.setStart(start);
+            }
+            return this;
+        }
+    }
 
 
-	private void addRules()
-	{
-		// last work day in month
-		mRules.add(new Unit(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1"), new TestRule(
-			"FREQ=MONTHLY;BYDAY=-1MO,-1TU,-1WE,-1TH,-1FR;BYSETPOS=-1"), new TestRule(
-			"FREQ=MONTHLY;BYMONTHDAY=26,27,28,29,30,31;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1")));
+    @Test
+    public void testEquivalence()
+    {
+        addRules();
+        for (Unit ruleUnit : mRules)
+        {
+            assertTrue(ruleUnit.compareRules());
+        }
+    }
 
-		// first work day in month
-		mRules.add(new Unit(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=1"), new TestRule("FREQ=MONTHLY;BYDAY=1MO,1TU,1WE,1TH,1FR;BYSETPOS=1"),
-			new TestRule("FREQ=MONTHLY;BYMONTHDAY=1,2,3;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=1")));
 
-		// last month in year
-		mRules.add(new Unit(new TestRule("FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYSETPOS=-1"), new TestRule("FREQ=MONTHLY;BYMONTH=12"), new TestRule(
-			"FREQ=DAILY;BYMONTH=12;BYMONTHDAY=1")).setStart("20101201"));
+    private void addRules()
+    {
+        // last work day in month
+        mRules.add(new Unit(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1"), new TestRule(
+            "FREQ=MONTHLY;BYDAY=-1MO,-1TU,-1WE,-1TH,-1FR;BYSETPOS=-1"), new TestRule(
+            "FREQ=MONTHLY;BYMONTHDAY=26,27,28,29,30,31;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1")));
 
-		mRules.add(new Unit(new TestRule("FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYSETPOS=-1"), new TestRule("FREQ=MONTHLY;BYMONTH=12"), new TestRule(
-			"FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=27"), new TestRule("FREQ=DAILY;BYMONTH=12;BYMONTHDAY=27")).setStart("20101227"));
+        // first work day in month
+        mRules.add(new Unit(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=1"), new TestRule("FREQ=MONTHLY;BYDAY=1MO,1TU,1WE,1TH,1FR;BYSETPOS=1"),
+            new TestRule("FREQ=MONTHLY;BYMONTHDAY=1,2,3;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=1")));
 
-		mRules.add(new Unit(new TestRule("FREQ=DAILY;BYMONTH=2;BYMONTHDAY=1"), new TestRule("FREQ=YEARLY;BYMONTH=2")));
-		mRules.add(new Unit(new TestRule("FREQ=DAILY;BYMONTH=2;BYMONTHDAY=3"), new TestRule("FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=3")).setStart("20100505"));
-		mRules.add(new Unit(new TestRule("FREQ=DAILY;BYMONTH=5;BYMONTHDAY=15"), new TestRule("FREQ=MONTHLY;BYMONTH=5;BYMONTHDAY=15"), new TestRule(
-			"FREQ=MONTHLY;BYMONTH=5"), new TestRule("FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=15"), new TestRule("FREQ=YEARLY")).setStart("19890515"));
+        // last month in year
+        mRules.add(new Unit(new TestRule("FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYSETPOS=-1"), new TestRule("FREQ=MONTHLY;BYMONTH=12"), new TestRule(
+            "FREQ=DAILY;BYMONTH=12;BYMONTHDAY=1")).setStart("20101201"));
 
-		mRules.add(new Unit(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=1,3,5,7,9"), new TestRule("FREQ=MONTHLY;BYMONTHDAY=1,3,5,7,9"))
-			.setStart("20010101"));
+        mRules.add(new Unit(new TestRule("FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYSETPOS=-1"), new TestRule("FREQ=MONTHLY;BYMONTH=12"), new TestRule(
+            "FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=27"), new TestRule("FREQ=DAILY;BYMONTH=12;BYMONTHDAY=27")).setStart("20101227"));
 
-		mRules.add(new Unit(new TestRule("FREQ=MONTHLY;INTERVAL=12;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=1,3,-1,-3,-5"), new TestRule(
-			"FREQ=YEARLY;BYYEARDAY=1,3,31,29,27")).setStart("20010101"));
+        mRules.add(new Unit(new TestRule("FREQ=DAILY;BYMONTH=2;BYMONTHDAY=1"), new TestRule("FREQ=YEARLY;BYMONTH=2")));
+        mRules.add(new Unit(new TestRule("FREQ=DAILY;BYMONTH=2;BYMONTHDAY=3"), new TestRule("FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=3")).setStart("20100505"));
+        mRules.add(new Unit(new TestRule("FREQ=DAILY;BYMONTH=5;BYMONTHDAY=15"), new TestRule("FREQ=MONTHLY;BYMONTH=5;BYMONTHDAY=15"), new TestRule(
+            "FREQ=MONTHLY;BYMONTH=5"), new TestRule("FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=15"), new TestRule("FREQ=YEARLY")).setStart("19890515"));
 
-		mRules.add(new Unit(new TestRule("FREQ=YEARLY;BYMONTH=1,3,5,7,8,10,12;BYMONTHDAY=25,26,27,28,29,30,31;BYDAY=TH"), new TestRule(
-			"FREQ=MONTHLY;BYMONTH=1,3,5,7,8,10,12;BYDAY=TH;BYSETPOS=-1"), new TestRule(
-			"FREQ=DAILY;BYMONTH=1,3,5,7,8,10,12;BYMONTHDAY=25,26,27,28,29,30,31;BYDAY=TH"), new TestRule("FREQ=MONTHLY;BYMONTH=1,3,5,7,8,10,12;BYDAY=-1TH")));
+        mRules.add(new Unit(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=1,3,5,7,9"), new TestRule("FREQ=MONTHLY;BYMONTHDAY=1,3,5,7,9"))
+            .setStart("20010101"));
 
-		mRules.add(new Unit(new TestRule("FREQ=HOURLY;BYSECOND=27;BYMINUTE=0,15,30,45"), new TestRule("FREQ=MINUTELY;BYMINUTE=0,15,30,45;BYSECOND=27"),
-			new TestRule("FREQ=SECONDLY;BYMINUTE=0,15,30,45;BYSECOND=27")).setStart("20120101T053027"));
+        mRules.add(new Unit(new TestRule("FREQ=MONTHLY;INTERVAL=12;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=1,3,-1,-3,-5"), new TestRule(
+            "FREQ=YEARLY;BYYEARDAY=1,3,31,29,27")).setStart("20010101"));
 
-		mRules.add(new Unit(new TestRule("FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=15"), new TestRule("FREQ=HOURLY;BYDAY=MO,WE,FR;BYHOUR=15")));
-		mRules.add(new Unit(new TestRule("FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=15"), new TestRule("FREQ=HOURLY;BYDAY=MO,WE,FR;BYHOUR=15")).setStart("20090713"));
+        mRules.add(new Unit(new TestRule("FREQ=YEARLY;BYMONTH=1,3,5,7,8,10,12;BYMONTHDAY=25,26,27,28,29,30,31;BYDAY=TH"), new TestRule(
+            "FREQ=MONTHLY;BYMONTH=1,3,5,7,8,10,12;BYDAY=TH;BYSETPOS=-1"), new TestRule(
+            "FREQ=DAILY;BYMONTH=1,3,5,7,8,10,12;BYMONTHDAY=25,26,27,28,29,30,31;BYDAY=TH"), new TestRule("FREQ=MONTHLY;BYMONTH=1,3,5,7,8,10,12;BYDAY=-1TH")));
 
-	}
+        mRules.add(new Unit(new TestRule("FREQ=HOURLY;BYSECOND=27;BYMINUTE=0,15,30,45"), new TestRule("FREQ=MINUTELY;BYMINUTE=0,15,30,45;BYSECOND=27"),
+            new TestRule("FREQ=SECONDLY;BYMINUTE=0,15,30,45;BYSECOND=27")).setStart("20120101T053027"));
+
+        mRules.add(new Unit(new TestRule("FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=15"), new TestRule("FREQ=HOURLY;BYDAY=MO,WE,FR;BYHOUR=15")));
+        mRules.add(new Unit(new TestRule("FREQ=WEEKLY;BYDAY=MO,WE,FR;BYHOUR=15"), new TestRule("FREQ=HOURLY;BYDAY=MO,WE,FR;BYHOUR=15")).setStart("20090713"));
+
+    }
 }

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceIteratorTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceIteratorTest.java
@@ -20,18 +20,14 @@ package org.dmfs.rfc5545.recur;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.recur.RecurrenceRule.RfcMode;
 import org.dmfs.rfc5545.recur.RecurrenceRule.Skip;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class RecurrenceIteratorTest
@@ -46,12 +42,6 @@ public class RecurrenceIteratorTest
     private final static DateTime ALLDAY_TEST_START_DATE = DateTime.parse("19850501");
 
     private final static List<TestRule> mTestRules = new ArrayList<TestRule>();
-
-
-    @Before
-    public void setUp() throws Exception
-    {
-    }
 
 
     @Test
@@ -207,8 +197,8 @@ public class RecurrenceIteratorTest
                 // check that the previous instance is always before the next instance
                 String errMsg = "";
                 errMsg = "instance no " + count + " " + lastInstance + " not before " + instance + " in rule "
-                        + new RecurrenceRule(rule.rule, RfcMode.RFC5545_LAX).toString();
-                assertTrue(errMsg, lastInstance.before(instance));
+                    + new RecurrenceRule(rule.rule, RfcMode.RFC5545_LAX).toString();
+                assertTrue(lastInstance.before(instance), errMsg);
 
                 lastInstance = instance;
                 count++;
@@ -225,8 +215,6 @@ public class RecurrenceIteratorTest
     /**
      * This test ensures that the rule is correctly evaluated when you move the start to a later instance. To do so it iterates over one rule and starts a new
      * iteration for every instance (using that instance as the start date). Then it compares the next instances of both iterations.
-     *
-     * @throws InvalidRecurrenceRuleException
      */
     @Test
     public void testWalkingStart() throws InvalidRecurrenceRuleException
@@ -342,7 +330,7 @@ public class RecurrenceIteratorTest
                 ffIterator.fastForward(fftodate);
                 int count = 0;
 
-                // fast forward original manually
+                // fast-forward original manually
                 while (original.hasNext() && original.peekMillis() < fftodate)
                 {
 
@@ -357,7 +345,7 @@ public class RecurrenceIteratorTest
                 {
                     try
                     {
-                        assertEquals(rule.rule, original.nextMillis(), ffIterator.nextMillis());
+                        assertEquals(original.nextMillis(), ffIterator.nextMillis(), rule.rule);
                     }
                     catch (IllegalStateException e)
                     {
@@ -368,7 +356,7 @@ public class RecurrenceIteratorTest
 
                 if (count < MAX_ITERATIONS)
                 {
-                    assertEquals(rule.rule, original.hasNext(), ffIterator.hasNext());
+                    assertEquals(original.hasNext(), ffIterator.hasNext(), rule.rule);
                 }
             }
         }
@@ -425,9 +413,9 @@ public class RecurrenceIteratorTest
     public void testSpecial() throws InvalidRecurrenceRuleException
     {
         TestRule rule = new TestRule("FREQ=YEARLY;BYWEEKNO=1").setStart("20180101")
-                .setMonths(12, 1)
-                .setMonthdays(29, 30, 31, 1, 2, 3, 4)
-                .setWeekdays(Calendar.MONDAY);
+            .setMonths(12, 1)
+            .setMonthdays(29, 30, 31, 1, 2, 3, 4)
+            .setWeekdays(Calendar.MONDAY);
 
         DateTime lastInstance = null;
         try
@@ -472,7 +460,7 @@ public class RecurrenceIteratorTest
                 // first instance of r2 should be lastInstance
                 String error1 = "";
                 // error1 = "error on first instance of rule " + rule.rule + " after " + count + " iterations ";
-                assertEquals(error1, lastInstance, i2.nextDateTime());
+                assertEquals(lastInstance, i2.nextDateTime(), error1);
 
                 lastInstance = it.nextDateTime();
                 System.out.println("x " + lastInstance);
@@ -484,7 +472,7 @@ public class RecurrenceIteratorTest
                 // check that the second instance of i2 equals the current instance of i
                 String error2 = "";
                 // error2 = "error on rule " + rule.rule + " after " + count + " iterations ";
-                assertEquals(error2, lastInstance, upcoming2);
+                assertEquals(lastInstance, upcoming2, error2);
             }
         }
         catch (ArrayIndexOutOfBoundsException e)
@@ -521,18 +509,18 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;COUNT=6;BYDAY=-2MO").setCount(6));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;COUNT=25;BYDAY=2WE,4WE").setCount(25));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3SA;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;COUNT=1000;WKST=SU").setCount(1000).setMonths(1, 2,
-                3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+            3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3SA;COUNT=24;WKST=SU").setCount(24));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3SU;BYMONTH=1,2,3,4,5,10,11,12;COUNT=8;WKST=SU").setCount(8).setMonths(1, 2, 3, 4, 5, 10,
-                11, 12));
+            11, 12));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3SU;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;COUNT=24;WKST=SU").setCount(24).setMonths(1, 2, 3,
-                4, 5, 6, 7, 8, 9, 10, 11, 12));
+            4, 5, 6, 7, 8, 9, 10, 11, 12));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3TU;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;COUNT=24;WKST=SU").setCount(24).setMonths(1, 2, 3,
-                4, 5, 6, 7, 8, 9, 10, 11, 12));
+            4, 5, 6, 7, 8, 9, 10, 11, 12));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+4FR;BYMONTH=1,2,3,4,5,7,8,9,10,11,12;COUNT=24;WKST=SU").setCount(24).setMonths(1, 2, 3, 4,
-                5, 7, 8, 9, 10, 11, 12));
+            5, 7, 8, 9, 10, 11, 12));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+4SA;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;COUNT=24;WKST=SU").setCount(24).setMonths(1, 2, 3,
-                4, 5, 6, 7, 8, 9, 10, 11, 12));
+            4, 5, 6, 7, 8, 9, 10, 11, 12));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;COUNT=24;BYDAY=2MO,4MO").setCount(24));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;COUNT=24;BYDAY=3TU").setCount(24));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU").setCount(10));
@@ -575,7 +563,7 @@ public class RecurrenceIteratorTest
         /* rules limited by UNTIL */
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=14;UNTIL=20130620T035959Z;WKST=SU").setUntil("20130620T035959Z"));
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR;UNTIL=20130928T065959Z;WKST=SU").setUntil("20130928T065959Z").setWeekdays(
-                Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=1;UNTIL=20120331T035959Z").setUntil("20120331T035959Z"));
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=1;UNTIL=20120514T220000Z").setUntil("20120514T220000Z"));
         mTestRules.add(new TestRule("FREQ=DAILY;INTERVAL=1;UNTIL=20130810T035959Z;WKST=SU").setUntil("20130810T035959Z"));
@@ -602,45 +590,45 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=1MO;UNTIL=20121231T203000Z").setUntil("20121231T203000Z").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=1TU;UNTIL=20131231T203000Z").setUntil("20131231T203000Z").setWeekdays(Calendar.TUESDAY));
         mTestRules
-                .add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=2TH,4TH;UNTIL=20091210T200000Z").setUntil("20091210T200000Z").setWeekdays(Calendar.THURSDAY));
+            .add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=2TH,4TH;UNTIL=20091210T200000Z").setUntil("20091210T200000Z").setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=2TU,4TU;UNTIL=20100323T210000Z").setUntil("20100323T210000Z").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=-1MO;BYMONTH=5;UNTIL=20140602T075959Z;WKST=SU").setUntil("20140602T075959Z").setWeekdays(
-                Calendar.MONDAY));
+            Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+1MO;UNTIL=20161206T045959Z;WKST=SU").setUntil("20161206T045959Z").setWeekdays(
-                Calendar.MONDAY));
+            Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+1SA,+3SA;UNTIL=20130530T035959Z;WKST=SU").setUntil("20130530T035959Z").setWeekdays(
-                Calendar.SATURDAY));
+            Calendar.SATURDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=-1SU;UNTIL=20150103T045959Z;WKST=SU").setUntil("20150103T045959Z").setWeekdays(
-                Calendar.SUNDAY));
+            Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+1TH,+3TH;UNTIL=20121217T045959Z;WKST=SU").setUntil("20121217T045959Z").setWeekdays(
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+1TH,+3TH;UNTIL=20140102T045959Z;WKST=SU").setUntil("20140102T045959Z").setWeekdays(
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+1WE;UNTIL=20140101T075959Z;WKST=SU").setUntil("20140101T075959Z").setWeekdays(
-                Calendar.WEDNESDAY));
+            Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+2MO;UNTIL=20150101T045959Z;WKST=SU").setUntil("20150101T045959Z").setWeekdays(
-                Calendar.MONDAY));
+            Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+2SA;UNTIL=20150106T045959Z;WKST=SU").setUntil("20150106T045959Z").setWeekdays(
-                Calendar.SATURDAY));
+            Calendar.SATURDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+2SU;UNTIL=20140101T045959Z;WKST=SU").setUntil("20140101T045959Z").setWeekdays(
-                Calendar.SUNDAY));
+            Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3MO;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;UNTIL=20131231T235959Z;WKST=MO")
-                .setUntil("20131231T235959Z").setMonths(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).setWeekdays(Calendar.MONDAY));
+            .setUntil("20131231T235959Z").setMonths(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3MO;UNTIL=20121201T095959Z;WKST=SU").setUntil("20121201T095959Z").setWeekdays(
-                Calendar.MONDAY));
+            Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3TH;UNTIL=20140101T045959Z;WKST=SU").setUntil("20140101T045959Z").setWeekdays(
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3TH;UNTIL=20140102T045959Z;WKST=SU").setUntil("20140102T045959Z").setWeekdays(
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3TU;BYMONTH=1,3,5,7,9,11;UNTIL=20131231T235959Z;WKST=MO").setUntil("20131231T235959Z")
-                .setMonths(1, 3, 5, 7, 9, 11).setWeekdays(Calendar.TUESDAY));
+            .setMonths(1, 3, 5, 7, 9, 11).setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3TU;UNTIL=20131231T235959Z;WKST=MO").setUntil("20131231T235959Z").setWeekdays(
-                Calendar.TUESDAY));
+            Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=3WE;UNTIL=20121231T183000Z").setUntil("20121231T183000Z").setWeekdays(Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+4TU;UNTIL=20140101T075959Z;WKST=SU").setUntil("20140101T075959Z").setWeekdays(
-                Calendar.TUESDAY));
+            Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+4WE;UNTIL=20131231T235959Z;WKST=MO").setUntil("20131231T235959Z").setWeekdays(
-                Calendar.WEDNESDAY));
+            Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1;UNTIL=20031101T233000Z").setUntil("20031101T233000Z").setMonthdays(1));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;UNTIL=20040701T065959Z;BYMONTHDAY=1").setUntil("20040701T065959Z").setMonthdays(1));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;UNTIL=20040702T065959Z;BYMONTHDAY=2").setUntil("20040702T065959Z").setMonthdays(2));
@@ -649,7 +637,7 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;UNTIL=20140518;BYDAY=1SU").setUntil("20140518").setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;UNTIL=20140518;BYDAY=3SU").setUntil("20140518").setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=2;BYDAY=+4TU;UNTIL=20131101T065959Z;WKST=SU").setUntil("20131101T065959Z").setWeekdays(
-                Calendar.TUESDAY));
+            Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=3;UNTIL=20210107T095959Z;WKST=SU").setUntil("20210107T095959Z"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;UNTIL=19971224T000000Z;BYDAY=1FR").setUntil("19971224T000000Z").setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;UNTIL=20091224T000000Z;BYDAY=1FR").setUntil("20091224T000000Z").setWeekdays(Calendar.FRIDAY));
@@ -659,24 +647,24 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=FR;UNTIL=20121214T235959Z;INTERVAL=1").setUntil("20121214T235959Z").setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=FR;UNTIL=20130329T235959Z;INTERVAL=1").setUntil("20130329T235959Z").setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO,TH;UNTIL=20050203T000000Z").setUntil("20050203T000000Z").setWeekdays(Calendar.MONDAY,
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20031010T000000Z").setUntil("20031010T000000Z").setWeekdays(Calendar.MONDAY,
-                Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20040227T000000Z").setUntil("20040227T000000Z").setWeekdays(Calendar.MONDAY,
-                Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;UNTIL=20050408T000000Z").setUntil("20050408T000000Z").setWeekdays(Calendar.MONDAY,
-                Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO;UNTIL=20080630T110000;WKST=MO").setUntil("20080630T110000").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO;UNTIL=20121210T235959Z;INTERVAL=1").setUntil("20121210T235959Z").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO;UNTIL=20130325T235959Z;INTERVAL=1").setUntil("20130325T235959Z").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TH;UNTIL=20050203T000000Z").setUntil("20050203T000000Z").setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TH;UNTIL=20050715T000000Z").setUntil("20050715T000000Z").setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TU,FR;UNTIL=20050523T000000Z").setUntil("20050523T000000Z").setWeekdays(Calendar.TUESDAY,
-                Calendar.FRIDAY));
+            Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TU,FR;UNTIL=20050715T000000Z").setUntil("20050715T000000Z").setWeekdays(Calendar.TUESDAY,
-                Calendar.FRIDAY));
+            Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TU,TH,FR;UNTIL=20030718T000000Z").setUntil("20030718T000000Z").setWeekdays(Calendar.TUESDAY,
-                Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TU;UNTIL=20030715T000000Z").setUntil("20030715T000000Z").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TU;UNTIL=20050201T000000Z").setUntil("20050201T000000Z").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TU;UNTIL=20050713T000000Z").setUntil("20050713T000000Z").setWeekdays(Calendar.TUESDAY));
@@ -686,49 +674,49 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=WE;UNTIL=20050715T000000Z").setUntil("20050715T000000Z").setWeekdays(Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=WE;UNTIL=20081219T123000;WKST=MO").setUntil("20081219T123000").setWeekdays(Calendar.WEDNESDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=FR;UNTIL=20140101T075959Z;WKST=SU").setUntil("20140101T075959Z").setWeekdays(Calendar.FRIDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=FR;UNTIL=20140101T075959Z;WKST=SU").setUntil("20140101T075959Z").setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH;UNTIL=20130614T065959Z;WKST=SU").setUntil("20130614T065959Z").setWeekdays(
-                Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY));
+            Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;UNTIL=20130505T045959Z").setUntil("20130505T045959Z").setWeekdays(Calendar.MONDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;UNTIL=20131231T235959Z;WKST=MO").setUntil("20131231T235959Z").setWeekdays(Calendar.MONDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;UNTIL=20131231T235959Z;WKST=MO").setUntil("20131231T235959Z").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SA;UNTIL=20130609T065959Z;WKST=SU").setUntil("20130609T065959Z").setWeekdays(
-                Calendar.SATURDAY));
+            Calendar.SATURDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SA;UNTIL=20251004T000000Z").setUntil("20251004T000000Z").setWeekdays(Calendar.SATURDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU,SA;UNTIL=20130625T065959Z;WKST=SU").setUntil("20130625T065959Z").setWeekdays(
-                Calendar.SUNDAY, Calendar.SATURDAY));
+            Calendar.SUNDAY, Calendar.SATURDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU,SA;UNTIL=20130930T065959Z;WKST=SU").setUntil("20130930T065959Z").setWeekdays(
-                Calendar.SUNDAY, Calendar.SATURDAY));
+            Calendar.SUNDAY, Calendar.SATURDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20130527T035959Z;WKST=SU").setUntil("20130527T035959Z").setWeekdays(Calendar.SUNDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20130527T035959Z;WKST=SU").setUntil("20130527T035959Z").setWeekdays(Calendar.SUNDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20130528T035959Z;WKST=SU").setUntil("20130528T035959Z").setWeekdays(Calendar.SUNDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20130528T035959Z;WKST=SU").setUntil("20130528T035959Z").setWeekdays(Calendar.SUNDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20130610T065959Z;WKST=SU").setUntil("20130610T065959Z").setWeekdays(Calendar.SUNDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20130610T065959Z;WKST=SU").setUntil("20130610T065959Z").setWeekdays(Calendar.SUNDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20131101T035959Z;WKST=SU").setUntil("20131101T035959Z").setWeekdays(Calendar.SUNDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20131101T035959Z;WKST=SU").setUntil("20131101T035959Z").setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20171220T000000Z").setUntil("20171220T000000Z").setWeekdays(Calendar.SUNDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20210106T045959Z;WKST=SU").setUntil("20210106T045959Z").setWeekdays(Calendar.SUNDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20210106T045959Z;WKST=SU").setUntil("20210106T045959Z").setWeekdays(Calendar.SUNDAY));
         mTestRules
-                .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20210109T045959Z;WKST=SU").setUntil("20210109T045959Z").setWeekdays(Calendar.SUNDAY));
+            .add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20210109T045959Z;WKST=SU").setUntil("20210109T045959Z").setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;UNTIL=20251005T000000Z").setUntil("20251005T000000Z").setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TH;UNTIL=20120317T075959Z;WKST=SU").setUntil("20120317T075959Z").setWeekdays(
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TH;UNTIL=20130531T035959Z;WKST=SU").setUntil("20130531T035959Z").setWeekdays(
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TH;UNTIL=20130701T035959Z;WKST=SU").setUntil("20130701T035959Z").setWeekdays(
-                Calendar.THURSDAY));
+            Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TH;UNTIL=20251215T000000Z").setUntil("20251215T000000Z").setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;UNTIL=20100525T210000Z").setUntil("20100525T210000Z").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;UNTIL=20110508T045959Z").setUntil("20110508T045959Z").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;UNTIL=20140128T235959Z;WKST=MO").setUntil("20140128T235959Z")
-                .setWeekdays(Calendar.TUESDAY));
+            .setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;UNTIL=20251215T000000Z").setUntil("20251215T000000Z").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=TU;UNTIL=20251230T000000Z").setUntil("20251230T000000Z").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20071231T191500").setUntil("20071231T191500").setWeekdays(Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20131231T235959Z;WKST=MO").setUntil("20131231T235959Z").setWeekdays(
-                Calendar.WEDNESDAY));
+            Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20250924T000000Z").setUntil("20250924T000000Z").setWeekdays(Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20250925T000000Z").setUntil("20250925T000000Z").setWeekdays(Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20251220T000000Z").setUntil("20251220T000000Z").setWeekdays(Calendar.WEDNESDAY));
@@ -744,7 +732,7 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;UNTIL=20120503T035959Z").setUntil("20120503T035959Z"));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;UNTIL=20140102T135959Z;WKST=SU").setUntil("20140102T135959Z"));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=2;UNTIL=20091224T000000Z;WKST=SU;BYDAY=MO,WE,FR").setUntil("20091224T000000Z").setWeekdays(
-                Calendar.MONDAY, Calendar.WEDNESDAY, Calendar.FRIDAY));
+            Calendar.MONDAY, Calendar.WEDNESDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=2;UNTIL=20120321T035959Z;WKST=SU").setUntil("20120321T035959Z"));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=2;UNTIL=21001230T173000Z;BYDAY=MO").setUntil("21001230T173000Z"));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=4;BYDAY=SA;UNTIL=20131207T220000Z").setUntil("20131207T220000Z"));
@@ -797,9 +785,9 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=10;UNTIL=20061029T090000Z").setUntil("20061029T090000Z").setMonths(10));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=4;UNTIL=20060402T090000Z").setUntil("20060402T090000Z").setMonths(4));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;BYMONTH=10;BYMONTHDAY=31;UNTIL=20160102T095959Z;WKST=SU").setUntil("20160102T095959Z")
-                .setMonths(10).setMonthdays(31));
+            .setMonths(10).setMonthdays(31));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;BYMONTH=1,4,6,9;BYMONTHDAY=15;UNTIL=20220102T045959Z;WKST=SU").setUntil("20220102T045959Z")
-                .setMonths(1, 4, 6, 9).setMonthdays(15));
+            .setMonths(1, 4, 6, 9).setMonthdays(15));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;UNTIL=20030317;BYMONTH=3").setUntil("20030317").setMonths(3));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;UNTIL=20131225T215959Z;WKST=MO").setUntil("20131225T215959Z"));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;UNTIL=20210106T095959Z;WKST=SU").setUntil("20210106T095959Z"));
@@ -841,9 +829,9 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=FR;BYMONTHDAY=13").setWeekdays(Calendar.FRIDAY).setMonthdays(13));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=FR;BYSETPOS=2").setWeekdays(Calendar.FRIDAY).setMonthdays(8, 9, 10, 11, 12, 13, 14));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1;WKST=SU").setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY,
-                Calendar.THURSDAY, Calendar.FRIDAY).setMonthdays(31, 30, 29, 28, 27, 26));
+            Calendar.THURSDAY, Calendar.FRIDAY).setMonthdays(31, 30, 29, 28, 27, 26));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2").setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY,
-                Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=SA;BYMONTHDAY=7,8,9,10,11,12,13").setWeekdays(Calendar.SATURDAY).setMonthdays(7, 8, 9, 10, 11, 12, 13));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYSETPOS=-1;WKST=SU"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=WE;BYSETPOS=1").setWeekdays(Calendar.WEDNESDAY));
@@ -865,11 +853,11 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=1TU,2TU,4TU,5TU").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=2TU,4TU").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=SU;BYMONTHDAY=13,7,8,9,10,11,12;BYMONTH=9").setMonths(9).setWeekdays(Calendar.SUNDAY)
-                .setMonthdays(13, 7, 8, 9, 10, 11, 12));
+            .setMonthdays(13, 7, 8, 9, 10, 11, 12));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8;BYMONTH=11").setMonths(11).setWeekdays(Calendar.TUESDAY)
-                .setMonthdays(2, 3, 4, 5, 6, 7, 8));
+            .setMonthdays(2, 3, 4, 5, 6, 7, 8));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=WE;BYMONTHDAY=25,26,27,21,22,23,24;BYMONTH=4").setMonths(4).setWeekdays(Calendar.WEDNESDAY)
-                .setMonthdays(25, 26, 27, 21, 22, 23, 24));
+            .setMonthdays(25, 26, 27, 21, 22, 23, 24));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1").setMonthdays(1));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;BYSETPOS=1;BYDAY=WE").setWeekdays(Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=2;BYDAY=TU").setWeekdays(Calendar.TUESDAY));
@@ -883,13 +871,13 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=TU;WKST=SU").setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=WE").setWeekdays(Calendar.WEDNESDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=0;BYDAY=MO,TU,WE,TH,FR").setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY,
-                Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1"));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=FR;").setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=FR;WKST=SU").setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR;WKST=SU").setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY,
-                Calendar.THURSDAY, Calendar.FRIDAY));
+            Calendar.THURSDAY, Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;WKST=SU").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SA").setWeekdays(Calendar.SATURDAY));
         mTestRules.add(new TestRule("FREQ=WEEKLY;INTERVAL=1;BYDAY=SU;WKST=SU").setWeekdays(Calendar.SUNDAY));
@@ -918,13 +906,13 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=5SU;BYHOUR=2;BYMINUTE=0;BYMONTH=10").setMonths(10).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=MO;BYWEEKNO=20").setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=SU;BYHOUR=2;BYMINUTE=0;BYMONTH=10;BYMONTHDAY=25,26").setMonths(10).setWeekdays(Calendar.SUNDAY)
-                .setMonthdays(25, 26));
+            .setMonthdays(25, 26));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=SU;BYHOUR=2;BYMINUTE=0;BYMONTH=11;BYMONTHDAY=1,2,3").setMonths(11).setWeekdays(Calendar.SUNDAY)
-                .setMonthdays(1, 2, 3));
+            .setMonthdays(1, 2, 3));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=SU;BYHOUR=2;BYMINUTE=0;BYMONTH=3;BYMONTHDAY=8,9,10").setMonths(3).setWeekdays(Calendar.SUNDAY)
-                .setMonthdays(8, 9, 10));
+            .setMonthdays(8, 9, 10));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=SU;BYHOUR=2;BYMINUTE=0;BYMONTH=4;BYMONTHDAY=1,2,3,4").setMonths(4).setWeekdays(Calendar.SUNDAY)
-                .setMonthdays(1, 2, 3, 4));
+            .setMonthdays(1, 2, 3, 4));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=TH;BYMONTH=3").setMonths(3).setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=TH;BYMONTH=6,7,8").setMonths(6, 7, 8).setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMINUTE=0;BYHOUR=2;BYDAY=-1SU;BYMONTH=10").setMonths(10).setWeekdays(Calendar.SUNDAY));
@@ -940,15 +928,15 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=10;BYDAY=3FR").setMonths(10).setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=10;BYDAY=3SU").setMonths(10).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=10;BYMONTHDAY=24,25,26,27,28,29,30;BYDAY=SA").setMonths(10).setWeekdays(Calendar.SATURDAY)
-                .setMonthdays(24, 25, 26, 27, 28, 29, 30));
+            .setMonthdays(24, 25, 26, 27, 28, 29, 30));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=10;BYMONTHDAY=9,10,11,12,13,14,15;BYDAY=SU").setMonths(10).setWeekdays(Calendar.SUNDAY)
-                .setMonthdays(9, 10, 11, 12, 13, 14, 15));
+            .setMonthdays(9, 10, 11, 12, 13, 14, 15));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=11;BYDAY=1SU").setMonths(11).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=12;BYDAY=-1SU").setMonths(12).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=12;BYDAY=FR;BYMONTHDAY=-1").setMonths(12).setWeekdays(Calendar.FRIDAY).setMonthdays(31));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=31").setMonths(12).setMonthdays(31));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1;BYDAY=MO,TU,WE,TH,FR;BYMONTHDAY=1,2,3;BYSETPOS=1").setMonths(1)
-                .setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY).setMonthdays(1, 2, 3));
+            .setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY).setMonthdays(1, 2, 3));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1").setMonths(1).setMonthdays(1));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=2").setMonths(1).setMonthdays(2));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=2;BYDAY=-1SU").setMonths(2).setWeekdays(Calendar.SUNDAY));
@@ -960,9 +948,9 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=3;BYDAY=3SU").setMonths(3).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=3;BYDAY=TH").setMonths(3).setWeekdays(Calendar.THURSDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=24,25,26,27,28,29,30;BYDAY=SA").setMonths(3).setWeekdays(Calendar.SATURDAY)
-                .setMonthdays(24, 25, 26, 27, 28, 29, 30));
+            .setMonthdays(24, 25, 26, 27, 28, 29, 30));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=9,10,11,12,13,14,15;BYDAY=SU").setMonths(3).setWeekdays(Calendar.SUNDAY)
-                .setMonthdays(9, 10, 11, 12, 13, 14, 15));
+            .setMonthdays(9, 10, 11, 12, 13, 14, 15));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=4;BYDAY=-1FR").setMonths(4).setWeekdays(Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=4;BYDAY=1SU").setMonths(4).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=4;BYDAY=3SU").setMonths(4).setWeekdays(Calendar.SUNDAY));
@@ -1014,34 +1002,34 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=1;BYMONTH=9").setMonths(9));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=2;BYMONTH=1;BYDAY=SU;BYHOUR=8,9;").setMonths(1).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;INTERVAL=4;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8;BYMONTH=11").setMonths(11).setWeekdays(Calendar.TUESDAY)
-                .setMonthdays(2, 3, 4, 5, 6, 7, 8));
+            .setMonthdays(2, 3, 4, 5, 6, 7, 8));
         mTestRules.add(new TestRule("FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTH=10;BYDAY=-1SU").setMonths(10).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTH=11;BYDAY=1SU").setMonths(11).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTH=3;BYDAY=-1SU").setMonths(3).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTH=3;BYDAY=2SU").setMonths(3).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;WKST=SU;BYDAY=1SU;BYMONTH=4").setMonths(4).setWeekdays(Calendar.SUNDAY));
         mTestRules.add(
-                new TestRule("FREQ=YEARLY;BYWEEKNO=1").setStart("20180101").setMonths(12, 1).setMonthdays(29, 30, 31, 1, 2, 3, 4).setWeekdays(Calendar.MONDAY));
+            new TestRule("FREQ=YEARLY;BYWEEKNO=1").setStart("20180101").setMonths(12, 1).setMonthdays(29, 30, 31, 1, 2, 3, 4).setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYWEEKNO=1,10;BYMONTHDAY=3").setStart("20180101").setMonthdays(3).setMonths(1, 3));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYWEEKNO=1,10;BYDAY=TU").setMonths(1, 3, 12).setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYWEEKNO=1,10;BYDAY=TU;BYMONTHDAY=3").setStart("20180101")
-                .setMonths(1, 3)
-                .setMonthdays(3)
-                .setWeekdays(Calendar.TUESDAY));
+            .setMonths(1, 3)
+            .setMonthdays(3)
+            .setWeekdays(Calendar.TUESDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYYEARDAY=1,100").setStart("20180101").setMonths(1, 4).setMonthdays(1, 9, 10));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1,2").setStart("20180101").setMonths(1, 2).setMonthdays(1));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1,2;BYWEEKNO=1,7,20").setStart("20180101").setMonths(1, 2).setWeekdays(Calendar.MONDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;WKST=SU;BYDAY=MO,WE,FR;BYMONTH=4,5").setMonths(4, 5).setWeekdays(Calendar.MONDAY, Calendar.WEDNESDAY,
-                Calendar.FRIDAY));
+            Calendar.FRIDAY));
         mTestRules.add(new TestRule("FREQ=YEARLY;WKST=SU;BYMONTH=5;BYMONTHDAY=-1 ").setMonths(5).setMonthdays(31));
         mTestRules.add(new TestRule("INTERVAL=1;FREQ=MONTHLY"));
 
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=1,3,5,7,9").setMonthdays(1, 3, 5, 7, 9).setStart("20010101"));
 
         mTestRules
-                .add(new TestRule(
-                        "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31;BYSETPOS=1,2,3")
-                        .setMonthdays(1, 2, 3));
+            .add(new TestRule(
+                "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31;BYSETPOS=1,2,3")
+                .setMonthdays(1, 2, 3));
 
         /*
          * Rules with a specific number of instances
@@ -1049,45 +1037,45 @@ public class RecurrenceIteratorTest
 
         // first 9 mondays of 2016
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=MO;BYMONTH=1,2;UNTIL=20161231").setStart("20160104").setUntil("20161231").setInstances(9)
-                .setWeekdays(Calendar.MONDAY).setLastInstance("20160229"));
+            .setWeekdays(Calendar.MONDAY).setLastInstance("20160229"));
 
         // test mixed BYDAY elements (with and without position).
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=MO,1SU,-1SA;UNTIL=20160831").setStart("20160801").setUntil("20160831").setInstances(7)
-                .setLastInstance("20160829"));
+            .setLastInstance("20160829"));
 
         // every day in 2012 -> 366 instances
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20121231").setStart("20120101").setUntil("20121231").setInstances(366).setLastInstance("20121231"));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20121231").setStart("20120101").setUntil("20121231").setInstances(366)
-                .setLastInstance("20121231"));
+            .setLastInstance("20121231"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20121231").setStart("20120101").setUntil("20121231").setInstances(366)
-                .setLastInstance("20121231"));
+            .setLastInstance("20121231"));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20121231").setStart("20120101").setUntil("20121231").setInstances(366)
-                .setLastInstance("20121231"));
+            .setLastInstance("20121231"));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20121231")
-                        .setStart("20120101").setUntil("20121231").setInstances(366).setLastInstance("20121231"));
+            .add(new TestRule(
+                "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20121231")
+                .setStart("20120101").setUntil("20121231").setInstances(366).setLastInstance("20121231"));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20121231")
-                        .setStart("20120101").setUntil("20121231").setInstances(366).setLastInstance("20121231"));
+            .add(new TestRule(
+                "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20121231")
+                .setStart("20120101").setUntil("20121231").setInstances(366).setLastInstance("20121231"));
 
         // every day in 2013 -> 365 instances
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20131231").setStart("20130101").setUntil("20131231").setInstances(365).setLastInstance("20131231"));
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20131231").setStart("20130101").setUntil("20131231").setInstances(365)
-                .setLastInstance("20131231"));
+            .setLastInstance("20131231"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20131231").setStart("20130101").setUntil("20131231").setInstances(365)
-                .setLastInstance("20131231"));
+            .setLastInstance("20131231"));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20131231").setStart("20130101").setUntil("20131231").setInstances(365)
-                .setLastInstance("20131231"));
+            .setLastInstance("20131231"));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
-                        .setStart("20130101").setUntil("20131231").setInstances(365));
+            .add(new TestRule(
+                "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
+                .setStart("20130101").setUntil("20131231").setInstances(365));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
-                        .setStart("20130101").setUntil("20131231").setInstances(365));
+            .add(new TestRule(
+                "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
+                .setStart("20130101").setUntil("20131231").setInstances(365));
 
         // every day in 2012 and 2013 -> 731 instances
         mTestRules.add(new TestRule("FREQ=HOURLY;INTERVAL=24;UNTIL=20131231").setStart("20120101").setUntil("20131231").setInstances(731));
@@ -1096,133 +1084,133 @@ public class RecurrenceIteratorTest
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20131231").setStart("20120101").setUntil("20131231").setInstances(731));
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=SU,MO,TH,WE,TU,FR,SA;UNTIL=20131231").setStart("20120101").setUntil("20131231").setInstances(731));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
-                        .setStart("20120101").setUntil("20131231").setInstances(731));
+            .add(new TestRule(
+                "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
+                .setStart("20120101").setUntil("20131231").setInstances(731));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31;UNTIL=20131231")
-                        .setStart("20120101").setUntil("20131231").setInstances(731));
+            .add(new TestRule(
+                "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31;UNTIL=20131231")
+                .setStart("20120101").setUntil("20131231").setInstances(731));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31;UNTIL=20131231")
-                        .setStart("20120101").setUntil("20131231").setInstances(731));
+            .add(new TestRule(
+                "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29,-30,-31;UNTIL=20131231")
+                .setStart("20120101").setUntil("20131231").setInstances(731));
         mTestRules
-                .add(new TestRule(
-                        "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
-                        .setStart("20120101").setUntil("20131231").setInstances(731));
+            .add(new TestRule(
+                "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
+                .setStart("20120101").setUntil("20131231").setInstances(731));
 
         // almost every day in 2013 (12*10 days are missing)
         mTestRules.add(new TestRule(
-                "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
-                .setStart("20130101").setUntil("20131231").setInstances(245)
-                .setMonthdays(1, 2, 3, 4, 5, 6, 7, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31));
+            "FREQ=MONTHLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
+            .setStart("20130101").setUntil("20131231").setInstances(245)
+            .setMonthdays(1, 2, 3, 4, 5, 6, 7, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31));
         mTestRules.add(new TestRule(
-                "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
-                .setStart("20130101").setUntil("20131231").setInstances(245)
-                .setMonthdays(1, 2, 3, 4, 5, 6, 7, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31));
+            "FREQ=YEARLY;BYMONTH=1,2,3,4,5,6,7,8,9,10,11,12;BYMONTHDAY=1,2,3,4,5,6,7,18,19,20,21,22,23,24,25,26,27,28,29,30,31;UNTIL=20131231")
+            .setStart("20130101").setUntil("20131231").setInstances(245)
+            .setMonthdays(1, 2, 3, 4, 5, 6, 7, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31));
 
         // every 2nd week in 2012 (except week 1) -> 25 instances
         mTestRules.add(new TestRule("FREQ=YEARLY;BYWEEKNO=3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53;UNTIL=20121231")
-                .setStart("20120101").setUntil("20121231").setInstances(25));
+            .setStart("20120101").setUntil("20121231").setInstances(25));
 
         // 2 instances in each month
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYDAY=1SU,-2MO;UNTIL=20131231").setStart("20130101").setUntil("20131231").setInstances(24)
-                .setWeekdays(Calendar.SUNDAY, Calendar.MONDAY));
+            .setWeekdays(Calendar.SUNDAY, Calendar.MONDAY));
 
         // 31th of Jan, March, May, July (no instances in September and November)
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1,3,5,7,9,11;BYMONTHDAY=31;UNTIL=20131231").setStart("20130131").setUntil("20131231")
-                .setMonths(1, 3, 5, 7).setMonthdays(31).setInstances(4).setMonthdays(31));
+            .setMonths(1, 3, 5, 7).setMonthdays(31).setInstances(4).setMonthdays(31));
 
         // 1 instance in Jan + 1 in Dec.
         mTestRules.add(new TestRule("FREQ=YEARLY;BYDAY=1SU,-2MO;UNTIL=20131231").setStart("20130101").setUntil("20131231").setMonths(1, 12).setInstances(2)
-                .setWeekdays(Calendar.SUNDAY, Calendar.MONDAY));
+            .setWeekdays(Calendar.SUNDAY, Calendar.MONDAY));
 
         // 3 * 31 instances
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYMONTH=1,3,5;BYDAY=SU,MO,TU,WE,TH,FR,SA;UNTIL=20131231").setStart("20130101").setUntil("20131231")
-                .setMonths(1, 3, 5).setInstances(3 * 31));
+            .setMonths(1, 3, 5).setInstances(3 * 31));
         // 3 * 31 instances
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1,3,5;BYDAY=SU,MO,TU,WE,TH,FR,SA;UNTIL=20131231").setStart("20130101").setUntil("20131231")
-                .setMonths(1, 3, 5).setInstances(3 * 31));
+            .setMonths(1, 3, 5).setInstances(3 * 31));
 
         // each Jan 31st : 5
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTHDAY=31;UNTIL=20171231").setStart("20130101").setUntil("20171231").setMonths(1).setInstances(5)
-                .setMonthdays(31));
+            .setMonthdays(31));
 
         // each Jan 29th day: 5
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTHDAY=29;UNTIL=20171231").setStart("20130101").setUntil("20171231").setMonthdays(29).setInstances(5));
 
         // each day between Jan 27th and Jan 31st that is in week 5: 4 + 5 + 5 + 0 + 2
         mTestRules.add(new TestRule("FREQ=YEARLY;BYMONTH=1;BYWEEKNO=5;BYMONTHDAY=27,28,29,30,31;UNTIL=20171231").setStart("20130101").setUntil("20171231")
-                .setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
+            .setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
 
         // each day between Jan 27th and Jan 31st that is in week 5: 4 + 5 + 5 + 0 + 2
         mTestRules.add(new TestRule("FREQ=MONTHLY;BYMONTH=1;BYWEEKNO=5;BYMONTHDAY=27,28,29,30,31;UNTIL=20171231", RfcMode.RFC2445_LAX).setStart("20130101")
-                .setUntil("20171231").setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
+            .setUntil("20171231").setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
 
         // each day between Jan 27th and Jan 31st that is in week 5: 4 + 5 + 5 + 0 + 2
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYMONTH=1;BYWEEKNO=5;BYMONTHDAY=27,28,29,30,31;UNTIL=20171231", RfcMode.RFC2445_LAX).setStart("20130101")
-                .setUntil("20171231").setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
+            .setUntil("20171231").setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
 
         // each day between Jan 27th and Jan 31st that is in week 5: 4 + 5 + 5 + 0 + 2
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYWEEKNO=5;BYMONTHDAY=27,28,29,30,31;UNTIL=20171231", RfcMode.RFC2445_LAX).setStart("20130101")
-                .setUntil("20171231").setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
+            .setUntil("20171231").setMonths(1).setWeeks(5).setMonthdays(27, 28, 29, 30, 31).setInstances(16));
 
         // every 1st -> 12 * 5 = 60 instances
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYMONTHDAY=1;UNTIL=20171231").setStart("20130101").setUntil("20171231").setMonthdays(1).setInstances(60));
         // every 1st in May, July and December -> 3 * 5 = 15 instances
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYMONTH=5,7,12;BYMONTHDAY=1;UNTIL=20171231").setStart("20130501").setUntil("20171231").setMonths(5, 7, 12)
-                .setMonthdays(1).setInstances(15));
+            .setMonthdays(1).setInstances(15));
         // every 31st -> 7 * 5 = 35 instances
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYMONTHDAY=31;UNTIL=20171231").setStart("20130131").setUntil("20171231").setMonthdays(31).setInstances(35));
         // every 31st in May, July and December -> 3 * 5 = 15 instances
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYMONTH=5,7,12;BYMONTHDAY=31;UNTIL=20171231").setStart("20130531").setUntil("20171231").setMonths(5, 7, 12)
-                .setMonthdays(31).setInstances(15));
+            .setMonthdays(31).setInstances(15));
 
         // every 2nd last day -> 12 * 5 = 60 instances
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYMONTHDAY=-2;UNTIL=20171231").setStart("20130130").setUntil("20171231").setMonthdays(27, 28, 29, 30)
-                .setInstances(5 * 12));
+            .setInstances(5 * 12));
         // every 2nd last day in May, July and December -> 3 * 5 = 15 instances
         mTestRules.add(new TestRule("FREQ=WEEKLY;BYMONTH=5,7,12;BYMONTHDAY=-2;UNTIL=20171231").setStart("20130530").setUntil("20171231").setMonths(5, 7, 12)
-                .setMonthdays(30).setInstances(15));
+            .setMonthdays(30).setInstances(15));
 
         mTestRules.add(new TestRule("FREQ=HOURLY;INTERVAL=2;UNTIL=20131231T235959Z").setStart("20120101T000000Z").setUntil("20131231T235959Z")
-                .setInstances(Math.min(MAX_ITERATIONS, 731 * 12)));
+            .setInstances(Math.min(MAX_ITERATIONS, 731 * 12)));
         mTestRules.add(new TestRule("FREQ=MINUTELY;INTERVAL=30;UNTIL=20120630T235959Z").setStart("20120101T000000Z").setUntil("20120630T235959Z")
-                .setInstances((31 + 29 + 31 + 30 + 31 + 30) * 24 * 2));
+            .setInstances((31 + 29 + 31 + 30 + 31 + 30) * 24 * 2));
         mTestRules.add(new TestRule("FREQ=SECONDLY;INTERVAL=900;UNTIL=20120331T235959Z").setStart("20120101T000000Z").setUntil("20120331T235959Z")
-                .setInstances((31 + 29 + 31) * 24 * 4));
+            .setInstances((31 + 29 + 31) * 24 * 4));
 
         mTestRules
-                .add(new TestRule(
-                        "FREQ=MONTHLY;BYMONTH=7,8;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;BYDAY=-1WE;UNTIL=20171231")
-                        .setStart("20130101").setUntil("20171231").setMonths(7, 8).setWeekdays(Calendar.WEDNESDAY).setMonthdays(25, 26, 27, 28, 29, 30, 31)
-                        .setInstances(10));
+            .add(new TestRule(
+                "FREQ=MONTHLY;BYMONTH=7,8;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;BYDAY=-1WE;UNTIL=20171231")
+                .setStart("20130101").setUntil("20171231").setMonths(7, 8).setWeekdays(Calendar.WEDNESDAY).setMonthdays(25, 26, 27, 28, 29, 30, 31)
+                .setInstances(10));
 
         mTestRules
-                .add(new TestRule(
-                        "FREQ=YEARLY;BYMONTH=2,4,6;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;BYDAY=2TH;UNTIL=20171231")
-                        .setStart("20130101").setUntil("20171231").setMonths(2, 4, 6).setWeekdays(Calendar.THURSDAY).setMonthdays(8, 9, 10, 11, 12, 13, 14)
-                        .setInstances(15));
+            .add(new TestRule(
+                "FREQ=YEARLY;BYMONTH=2,4,6;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;BYDAY=2TH;UNTIL=20171231")
+                .setStart("20130101").setUntil("20171231").setMonths(2, 4, 6).setWeekdays(Calendar.THURSDAY).setMonthdays(8, 9, 10, 11, 12, 13, 14)
+                .setInstances(15));
         mTestRules.add(new TestRule(
-                "FREQ=YEARLY;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;BYDAY=2TH;UNTIL=20171231")
-                .setStart("20130101").setUntil("20171231").setMonths(1).setWeekdays(Calendar.THURSDAY).setMonthdays(8, 9, 10, 11, 12, 13, 14).setInstances(5));
+            "FREQ=YEARLY;BYMONTHDAY=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31;BYDAY=2TH;UNTIL=20171231")
+            .setStart("20130101").setUntil("20171231").setMonths(1).setWeekdays(Calendar.THURSDAY).setMonthdays(8, 9, 10, 11, 12, 13, 14).setInstances(5));
 
         mTestRules.add(new TestRule(
-                "FREQ=YEARLY;BYMONTH=1,3;BYYEARDAY=1,31,59,60,61,62;COUNT=30").setStart("20180101")
-                .setMonths(1, 3)
-                .setMonthdays(1, 31, 28, 29, 2, 3)
-                .setCount(30));
+            "FREQ=YEARLY;BYMONTH=1,3;BYYEARDAY=1,31,59,60,61,62;COUNT=30").setStart("20180101")
+            .setMonths(1, 3)
+            .setMonthdays(1, 31, 28, 29, 2, 3)
+            .setCount(30));
         mTestRules.add(new TestRule(
-                "FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60;UNTIL=20181231").setStart("20180101")
-                .setMonths(1, 3)
-                .setMonthdays(1, 31)
-                .setInstances(3));
+            "FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60;UNTIL=20181231").setStart("20180101")
+            .setMonths(1, 3)
+            .setMonthdays(1, 31)
+            .setInstances(3));
         mTestRules.add(new TestRule(
-                "FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60;BYDAY=WE;UNTIL=20181231").setStart("20180101")
-                .setMonths(1)
-                .setMonthdays(31)
-                .setInstances(1));
+            "FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60;BYDAY=WE;UNTIL=20181231").setStart("20180101")
+            .setMonths(1)
+            .setMonthdays(31)
+            .setInstances(1));
 
         /**
          * Interval tests
@@ -1269,7 +1257,7 @@ public class RecurrenceIteratorTest
 
         // 20120101 was a Sunday
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20191231;BYWEEKNO=20").setStart("20120101").setInstances(8).setMonths(5).setWeekdays(Calendar.SUNDAY)
-                .setSeconds(0).setMinutes(0).setHours(0));
+            .setSeconds(0).setMinutes(0).setHours(0));
 
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20191231;BYMONTHDAY=5").setStart("20120101").setInstances(8).setMonthdays(5));
 
@@ -1281,102 +1269,102 @@ public class RecurrenceIteratorTest
         // mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20200101T010101Z;BYMONTH=3;BYDAY=-1SU;BYHOUR=2;BYMINUTE=30")
         // .setStart("20120101T010101", "Europe/Berlin").setInstances(1));
         mTestRules
-                .add(new TestRule("FREQ=YEARLY;UNTIL=20200101T010101;BYMONTH=10;BYDAY=-1SU;BYHOUR=2;BYMINUTE=30").setStart("20120101T010101").setInstances(8));
+            .add(new TestRule("FREQ=YEARLY;UNTIL=20200101T010101;BYMONTH=10;BYDAY=-1SU;BYHOUR=2;BYMINUTE=30").setStart("20120101T010101").setInstances(8));
 
         // leap years
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=30000101;BYMONTH=2;BYMONTHDAY=29").setStart("20000101").setInstances(25 * 10 - 7));
 
         // bysetpos
         mTestRules.add(new TestRule("FREQ=MONTHLY;UNTIL=20121231;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1").setStart("20120101").setInstances(12)
-                .setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
+            .setWeekdays(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY));
 
         // Rules with invalid UNTIL dates parsed in lax modes
         mTestRules.add(new TestRule("FREQ=WEEKLY;UNTIL=20140801T150000ZZ;INTERVAL=1;BYDAY=MO", RfcMode.RFC5545_LAX).setStart("20140701T150000Z")
-                .setInstances(4).setWeekdays(Calendar.MONDAY).setMonths(7).setMonthdays(1, 7, 14, 21, 28));
+            .setInstances(4).setWeekdays(Calendar.MONDAY).setMonths(7).setMonthdays(1, 7, 14, 21, 28));
         mTestRules.add(new TestRule("FREQ=WEEKLY;UNTIL=20140801T150000ZZ;INTERVAL=1;BYDAY=MO", RfcMode.RFC2445_LAX).setStart("20140701T150000Z")
-                .setInstances(4).setWeekdays(Calendar.MONDAY).setMonths(7).setMonthdays(1, 7, 14, 21, 28));
+            .setInstances(4).setWeekdays(Calendar.MONDAY).setMonths(7).setMonthdays(1, 7, 14, 21, 28));
 
         mTestRules.add(new TestRule("FREQ=MONTHLY;UNTIL=20120131T120000;BYHOUR=12").setStart("20120101T000000").setInstances(1).setHours(12));
 
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20120131T000000;BYHOUR=12").setStart("20120101T000000").setInstances(1).setMonths(1).setMonthdays(1)
-                .setHours(12));
+            .setHours(12));
 
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20121124T000000;BYMINUTE=12").setStart("20121123T000000").setInstances(1).setMonths(11)
-                .setMonthdays(23).setMinutes(12));
+            .setMonthdays(23).setMinutes(12));
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20120103T000000;BYMINUTE=12,24,36,48").setStart("20120101T000000").setInstances(4).setMonths(1)
-                .setMonthdays(1).setMinutes(12, 24, 36, 48));
+            .setMonthdays(1).setMinutes(12, 24, 36, 48));
 
         mTestRules.add(new TestRule("FREQ=YEARLY;UNTIL=20120731T000000;BYHOUR=12").setStart("20120707T000000").setInstances(1).setMonths(7).setMonthdays(7)
-                .setHours(12));
+            .setHours(12));
 
         /* Tests for RSCALE */
 
         mTestRules.add(new TestRule("FREQ=YEARLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=FORWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
-                .setStart("20130301").setUntil("29171231").setMonths(2, 3).setMonthdays(1, 29).setInstances(904));
+            .setStart("20130301").setUntil("29171231").setMonths(2, 3).setMonthdays(1, 29).setInstances(904));
         mTestRules.add(new TestRule("FREQ=YEARLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=BACKWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
-                .setStart("20130228").setUntil("29171231").setMonths(2).setMonthdays(28, 29).setInstances(905));
+            .setStart("20130228").setUntil("29171231").setMonths(2).setMonthdays(28, 29).setInstances(905));
         mTestRules.add(new TestRule("FREQ=YEARLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=OMIT;UNTIL=29171231", RfcMode.RFC2445_LAX).setStart("20130228")
-                .setUntil("29171231").setMonths(2).setMonthdays(1, 29).setInstances(219));
+            .setUntil("29171231").setMonths(2).setMonthdays(1, 29).setInstances(219));
         mTestRules.add(new TestRule("FREQ=MONTHLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=FORWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
-                .setStart("20130301").setUntil("29171231").setMonths(2, 3).setMonthdays(1, 29).setInstances(904));
+            .setStart("20130301").setUntil("29171231").setMonths(2, 3).setMonthdays(1, 29).setInstances(904));
         mTestRules.add(new TestRule("FREQ=MONTHLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=BACKWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
-                .setStart("20130228").setUntil("29171231").setMonths(2).setMonthdays(28, 29).setInstances(905));
+            .setStart("20130228").setUntil("29171231").setMonths(2).setMonthdays(28, 29).setInstances(905));
         mTestRules.add(new TestRule("FREQ=MONTHLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=OMIT;UNTIL=29171231", RfcMode.RFC2445_LAX).setStart("20130228")
-                .setUntil("20171231").setMonths(2).setMonthdays(1, 29).setInstances(219));
+            .setUntil("20171231").setMonths(2).setMonthdays(1, 29).setInstances(219));
         mTestRules.add(new TestRule("FREQ=MONTHLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=FORWARD;COUNT=20", RfcMode.RFC2445_LAX).setStart("20130301")
-                .setCount(20).setMonths(2, 3).setMonthdays(1, 29).setInstances(20));
+            .setCount(20).setMonths(2, 3).setMonthdays(1, 29).setInstances(20));
         mTestRules.add(new TestRule("FREQ=MONTHLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=BACKWARD;COUNT=20", RfcMode.RFC2445_LAX).setStart("20130228")
-                .setCount(20).setMonths(2).setMonthdays(28, 29).setInstances(20));
+            .setCount(20).setMonths(2).setMonthdays(28, 29).setInstances(20));
         mTestRules.add(new TestRule("FREQ=MONTHLY;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=OMIT;COUNT=20", RfcMode.RFC2445_LAX).setStart("20130228")
-                .setCount(20).setMonths(2).setMonthdays(1, 29).setInstances(20));
+            .setCount(20).setMonths(2).setMonthdays(1, 29).setInstances(20));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=48;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=FORWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
-                .setStart("20130228").setUntil("29171231").setMonths(3).setMonthdays(1).setInstances(227));
+            .setStart("20130228").setUntil("29171231").setMonths(3).setMonthdays(1).setInstances(227));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=48;RSCALE=gregorian;BYMONTH=2;BYMONTHDAY=29;SKIP=BACKWARD;UNTIL=29171231", RfcMode.RFC2445_LAX)
-                .setStart("20130228").setUntil("29171231").setMonths(2).setMonthdays(28).setInstances(227));
+            .setStart("20130228").setUntil("29171231").setMonths(2).setMonthdays(28).setInstances(227));
 
         /* Special rules for the skip all but last test */
 
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=3;COUNT=10;BYMONTHDAY=10,11,12,13,14,15").setStart("20090714").setCount(10)
-                .setMonthdays(10, 11, 12, 13, 14, 15).setLastInstance("20100111"));
+            .setMonthdays(10, 11, 12, 13, 14, 15).setLastInstance("20100111"));
 
         /* Special test for fast birthday iterator */
 
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=1;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20181010"));
+            .setMonthdays(10).setLastInstance("20181010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20181010"));
+            .setMonthdays(10).setLastInstance("20181010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=3;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20181010"));
+            .setMonthdays(10).setLastInstance("20181010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=4;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20181010"));
+            .setMonthdays(10).setLastInstance("20181010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=6;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20181010"));
+            .setMonthdays(10).setLastInstance("20181010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=12;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20181010"));
+            .setMonthdays(10).setLastInstance("20181010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=24;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20271010"));
+            .setMonthdays(10).setLastInstance("20271010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=36;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20361010"));
+            .setMonthdays(10).setLastInstance("20361010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=48;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20451010"));
+            .setMonthdays(10).setLastInstance("20451010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=5;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20541010"));
+            .setMonthdays(10).setLastInstance("20541010"));
         mTestRules.add(new TestRule("FREQ=MONTHLY;INTERVAL=10;COUNT=10;BYMONTH=10,BYMONTHDAY=10").setStart("20091010").setCount(10).setMonths(10)
-                .setMonthdays(10).setLastInstance("20541010"));
+            .setMonthdays(10).setLastInstance("20541010"));
 
         /* Test time zone related issues */
 
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20160521T060000Z").setStart("20160520T080000", "Europe/Berlin")
-                .setInstances(2)
-                .setLastInstance("20160521T080000", "Europe/Berlin"));
+            .setInstances(2)
+            .setLastInstance("20160521T080000", "Europe/Berlin"));
         mTestRules.add(
-                new TestRule("FREQ=DAILY;UNTIL=20160521T060000Z").setStart("20160520T080000", "UTC").setInstances(1).setLastInstance("20160520T080000", "UTC"));
+            new TestRule("FREQ=DAILY;UNTIL=20160521T060000Z").setStart("20160520T080000", "UTC").setInstances(1).setLastInstance("20160520T080000", "UTC"));
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20160521T060000Z").setStart("20160520T080000", "America/New_York")
-                .setInstances(1)
-                .setLastInstance("20160520T080000", "America/New_York"));
+            .setInstances(1)
+            .setLastInstance("20160520T080000", "America/New_York"));
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20160521T060000Z").setStart("20160520T080000", "Europe/Moscow")
-                .setInstances(2)
-                .setLastInstance("20160521T080000", "Europe/Moscow"));
+            .setInstances(2)
+            .setLastInstance("20160521T080000", "Europe/Moscow"));
 
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20160521T060000").setStart("20160520T050000").setInstances(2).setLastInstance("20160521T050000"));
         mTestRules.add(new TestRule("FREQ=DAILY;UNTIL=20160521T060000").setStart("20160520T060000").setInstances(2).setLastInstance("20160521T060000"));

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceParserTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceParserTest.java
@@ -1,377 +1,375 @@
 package org.dmfs.rfc5545.recur;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.rfc5545.recur.RecurrenceRule.RfcMode;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.dmfs.rfc5545.DateTime;
-import org.dmfs.rfc5545.recur.RecurrenceRule.RfcMode;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class RecurrenceParserTest
 {
-	private static Set<TestRuleWithException> mRules = new HashSet<TestRuleWithException>();
-	private static String defaultStart = "20120101";
-	private static final String[] byRules = { "INTERVAL=2", "BYSECOND=2", "BYMINUTE=2", "BYHOUR=2", "BYDAY=MO", "BYMONTHDAY=2", "BYYEARDAY=2", "BYWEEKNO=2",
-		"BYMONTH=2", "WKST=MO" };
-
-	public class TestRuleWithException extends TestRule
-	{
-
-		public Exception exception;
-		public Set<String> invalidRules = new HashSet<String>();
-		public Set<String> mustContain = new HashSet<String>();
+    private static Set<TestRuleWithException> mRules = new HashSet<TestRuleWithException>();
+    private static String defaultStart = "20120101";
+    private static final String[] byRules = {
+        "INTERVAL=2", "BYSECOND=2", "BYMINUTE=2", "BYHOUR=2", "BYDAY=MO", "BYMONTHDAY=2", "BYYEARDAY=2", "BYWEEKNO=2",
+        "BYMONTH=2", "WKST=MO" };
 
 
-		public TestRuleWithException(String rule)
-		{
-			super(rule);
-		}
+    public class TestRuleWithException extends TestRule
+    {
+
+        public Exception exception;
+        public Set<String> invalidRules = new HashSet<String>();
+        public Set<String> mustContain = new HashSet<String>();
 
 
-		public TestRuleWithException(String rule, RfcMode mode)
-		{
-			super(rule, mode);
-		}
+        public TestRuleWithException(String rule)
+        {
+            super(rule);
+        }
 
 
-		public TestRuleWithException setException(Exception excp)
-		{
-			exception = excp;
-			return this;
-		}
+        public TestRuleWithException(String rule, RfcMode mode)
+        {
+            super(rule, mode);
+        }
 
 
-		public TestRuleWithException setInstances(int instances)
-		{
-			super.setInstances(instances);
-			return this;
-		}
+        public TestRuleWithException setException(Exception excp)
+        {
+            exception = excp;
+            return this;
+        }
 
 
-		public TestRuleWithException setUntil(String until)
-		{
-			super.setUntil(until);
-			return this;
-		}
+        public TestRuleWithException setInstances(int instances)
+        {
+            super.setInstances(instances);
+            return this;
+        }
 
 
-		/**
-		 * Sets a list of rules that should be dropped after parsing.
-		 * 
-		 * @param invalidRules
-		 *            the rules
-		 * @return
-		 */
-		public TestRuleWithException setInvalidRules(String... invalidRules)
-		{
-			this.invalidRules = new HashSet<String>();
-			this.invalidRules.addAll(Arrays.asList(invalidRules));
-			return this;
-		}
+        public TestRuleWithException setUntil(String until)
+        {
+            super.setUntil(until);
+            return this;
+        }
 
 
-		/**
-		 * Asserts that the rules set in {@link setInvalidRules} are really dropped.
-		 * 
-		 * @param rule
-		 *            Rule that is returned by {@link RecurrenceRule.toString}
-		 */
-		public void assertInvalidRules(String rule)
-		{
-			for (String droppedRule : invalidRules)
-			{
-				assertFalse("Invalid rule detected that should have been dropped", rule.contains(droppedRule));
-			}
-		}
+        /**
+         * Sets a list of rules that should be dropped after parsing.
+         *
+         * @param invalidRules
+         *     the rules
+         */
+        public TestRuleWithException setInvalidRules(String... invalidRules)
+        {
+            this.invalidRules = new HashSet<String>();
+            this.invalidRules.addAll(Arrays.asList(invalidRules));
+            return this;
+        }
 
 
-		/**
-		 * A set of attributes the toString() output must contain.
-		 * 
-		 * @param mustContain
-		 *            the attributes
-		 */
-
-		public TestRuleWithException setObligatoryRuleParts(String... mustContain)
-		{
-			this.mustContain = new HashSet<String>();
-			this.mustContain.addAll(Arrays.asList(mustContain));
-			return this;
-		}
-
-
-		/**
-		 * Asserts that the toString() ouput contains the rule parts in <code>mustContain</code>
-		 * 
-		 * @param rule
-		 *            Rule that is returned by RecurrenceRule.toString
-		 */
-		public void assertObligatoryRuleParts(String rule)
-		{
-			for (String obligatoryRule : mustContain)
-			{
-				assertTrue("Missing rule in the output of toString", rule.contains(obligatoryRule));
-			}
-		}
-
-	}
+        /**
+         * Asserts that the rules set in {@link setInvalidRules} are really dropped.
+         *
+         * @param rule
+         *     Rule that is returned by {@link RecurrenceRule.toString}
+         */
+        public void assertInvalidRules(String rule)
+        {
+            for (String droppedRule : invalidRules)
+            {
+                assertFalse(rule.contains(droppedRule), "Invalid rule detected that should have been dropped");
+            }
+        }
 
 
-	@Test
-	public void testXParts() throws InvalidRecurrenceRuleException
-	{
-		RecurrenceRule r1 = new RecurrenceRule("FREQ=YEARLY;X-PART=1", RfcMode.RFC2445_STRICT);
+        /**
+         * A set of attributes the toString() output must contain.
+         *
+         * @param mustContain
+         *     the attributes
+         */
 
-		assertEquals("1", r1.getXPart("X-PART"));
-		assertEquals(null, r1.getXPart("X-PARTXY"));
-		assertTrue(r1.hasXPart("X-PART"));
-		assertFalse(r1.hasXPart("X-PARTXY"));
-
-		// override x-part
-
-		r1.setXPart("X-PART", "a");
-
-		assertEquals("a", r1.getXPart("X-PART"));
-		assertEquals(null, r1.getXPart("X-PARTXY"));
-		assertTrue(r1.hasXPart("X-PART"));
-		assertFalse(r1.hasXPart("X-PARTXY"));
-		assertEquals("FREQ=YEARLY;X-PART=a", r1.toString());
-
-		// add x-part
-
-		r1.setXPart("X-PARTXY", "xy");
-
-		assertEquals("a", r1.getXPart("X-PART"));
-		assertEquals("xy", r1.getXPart("X-PARTXY"));
-		assertTrue(r1.hasXPart("X-PART"));
-		assertTrue(r1.hasXPart("X-PARTXY"));
-		assertTrue(r1.toString().contains(";X-PART=a"));
-		assertTrue(r1.toString().contains(";X-PARTXY=xy"));
-
-		// remove x-part
-		r1.setXPart("X-PART", null);
-
-		assertEquals(null, r1.getXPart("X-PART"));
-		assertEquals("xy", r1.getXPart("X-PARTXY"));
-		assertFalse(r1.hasXPart("X-PART"));
-		assertTrue(r1.hasXPart("X-PARTXY"));
-		assertEquals("FREQ=YEARLY;X-PARTXY=xy", r1.toString());
-
-		// remove x-part
-		r1.setXPart("X-PARTXY", null);
-
-		assertEquals(null, r1.getXPart("X-PART"));
-		assertEquals(null, r1.getXPart("X-PARTXY"));
-		assertFalse(r1.hasXPart("X-PART"));
-		assertFalse(r1.hasXPart("X-PARTXY"));
-		assertEquals("FREQ=YEARLY", r1.toString());
-	}
+        public TestRuleWithException setObligatoryRuleParts(String... mustContain)
+        {
+            this.mustContain = new HashSet<String>();
+            this.mustContain.addAll(Arrays.asList(mustContain));
+            return this;
+        }
 
 
-	public void addInvalidWhiteSpaceTests()
-	{
-		final String s = "FREQ=YEARLY;BYMONTH=12";
-		for (int i = 0; i < s.length(); ++i)
-		{
-			StringBuffer sb = new StringBuffer(s);
-			sb.insert(i, " ");
-			mRules.add(new TestRuleWithException(sb.toString(), RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("Invalid whitespace - "
-				+ sb.toString())));
-		}
-	}
+        /**
+         * Asserts that the toString() ouput contains the rule parts in <code>mustContain</code>
+         *
+         * @param rule
+         *     Rule that is returned by RecurrenceRule.toString
+         */
+        public void assertObligatoryRuleParts(String rule)
+        {
+            for (String obligatoryRule : mustContain)
+            {
+                assertTrue(rule.contains(obligatoryRule), "Missing rule in the output of toString");
+            }
+        }
+
+    }
 
 
-	/**
-	 * Keywords must only occur once.
-	 */
-	private void addUniqueKeyWordTests()
-	{
-		String byRuleTemplate = "FREQ=YEARLY;";
-		for (int i = 0; i < byRules.length; ++i)
-		{
-			String rule = byRuleTemplate + byRules[i] + ";" + byRules[i];
-			mRules.add(new TestRuleWithException(rule, RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		}
-	}
+    @Test
+    public void testXParts() throws InvalidRecurrenceRuleException
+    {
+        RecurrenceRule r1 = new RecurrenceRule("FREQ=YEARLY;X-PART=1", RfcMode.RFC2445_STRICT);
+
+        assertEquals("1", r1.getXPart("X-PART"));
+        assertEquals(null, r1.getXPart("X-PARTXY"));
+        assertTrue(r1.hasXPart("X-PART"));
+        assertFalse(r1.hasXPart("X-PARTXY"));
+
+        // override x-part
+
+        r1.setXPart("X-PART", "a");
+
+        assertEquals("a", r1.getXPart("X-PART"));
+        assertEquals(null, r1.getXPart("X-PARTXY"));
+        assertTrue(r1.hasXPart("X-PART"));
+        assertFalse(r1.hasXPart("X-PARTXY"));
+        assertEquals("FREQ=YEARLY;X-PART=a", r1.toString());
+
+        // add x-part
+
+        r1.setXPart("X-PARTXY", "xy");
+
+        assertEquals("a", r1.getXPart("X-PART"));
+        assertEquals("xy", r1.getXPart("X-PARTXY"));
+        assertTrue(r1.hasXPart("X-PART"));
+        assertTrue(r1.hasXPart("X-PARTXY"));
+        assertTrue(r1.toString().contains(";X-PART=a"));
+        assertTrue(r1.toString().contains(";X-PARTXY=xy"));
+
+        // remove x-part
+        r1.setXPart("X-PART", null);
+
+        assertEquals(null, r1.getXPart("X-PART"));
+        assertEquals("xy", r1.getXPart("X-PARTXY"));
+        assertFalse(r1.hasXPart("X-PART"));
+        assertTrue(r1.hasXPart("X-PARTXY"));
+        assertEquals("FREQ=YEARLY;X-PARTXY=xy", r1.toString());
+
+        // remove x-part
+        r1.setXPart("X-PARTXY", null);
+
+        assertEquals(null, r1.getXPart("X-PART"));
+        assertEquals(null, r1.getXPart("X-PARTXY"));
+        assertFalse(r1.hasXPart("X-PART"));
+        assertFalse(r1.hasXPart("X-PARTXY"));
+        assertEquals("FREQ=YEARLY", r1.toString());
+    }
 
 
-	@Test
-	public void testRule()
-	{
-		/**
-		 * In RFC2445 a RecurrenceRule has to start with "FREQ=", in RFC5545 the order is arbitrary but it must occur.
-		 */
-		mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC2445_LAX).setInstances(0).setUntil("20130101"));
-		mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC5545_STRICT));
-		mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC5545_LAX));
+    public void addInvalidWhiteSpaceTests()
+    {
+        final String s = "FREQ=YEARLY;BYMONTH=12";
+        for (int i = 0; i < s.length(); ++i)
+        {
+            StringBuffer sb = new StringBuffer(s);
+            sb.insert(i, " ");
+            mRules.add(new TestRuleWithException(sb.toString(), RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("Invalid whitespace - "
+                + sb.toString())));
+        }
+    }
 
-		/**
-		 * Missing FREQ=
-		 */
-		mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("Without 'FREQ='")));
-		mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("without 'FREQ='")));
-		mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC5545_LAX).setException(new InvalidRecurrenceRuleException("Without 'FREQ='")));
-		mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC2445_LAX).setException(new InvalidRecurrenceRuleException("without 'FREQ='")));
 
-		/**
-		 * Duplicate FREQ
-		 */
-		mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYDAY=MO;FREQ=DAILY", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		// mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYDAY=MO;FREQ=DAILY", RfcMode.RFC5545_LAX).setException(new InvalidRecurrenceRuleException("")));
+    /**
+     * Keywords must only occur once.
+     */
+    private void addUniqueKeyWordTests()
+    {
+        String byRuleTemplate = "FREQ=YEARLY;";
+        for (int i = 0; i < byRules.length; ++i)
+        {
+            String rule = byRuleTemplate + byRules[i] + ";" + byRules[i];
+            mRules.add(new TestRuleWithException(rule, RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        }
+    }
 
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYMONHT=2", RfcMode.RFC5545_STRICT)
-			.setException(new InvalidRecurrenceRuleException("unknown keyword")));
 
-		/**
-		 * Missing value for BYxxx rule.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYMONTH=", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYMONTH=", RfcMode.RFC5545_LAX).setInstances(0));
+    @Test
+    public void testRule()
+    {
+        /**
+         * In RFC2445 a RecurrenceRule has to start with "FREQ=", in RFC5545 the order is arbitrary but it must occur.
+         */
+        mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC2445_LAX).setInstances(0).setUntil("20130101"));
+        mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC5545_STRICT));
+        mRules.add(new TestRuleWithException("BYDAY=MO;FREQ=WEEKLY", RfcMode.RFC5545_LAX));
 
-		/**
-		 * Invalid delimiter.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=YEARLY,BYMONTH=27", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        /**
+         * Missing FREQ=
+         */
+        mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("Without 'FREQ='")));
+        mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("without 'FREQ='")));
+        mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC5545_LAX).setException(new InvalidRecurrenceRuleException("Without 'FREQ='")));
+        mRules.add(new TestRuleWithException("BYDAY=MO", RfcMode.RFC2445_LAX).setException(new InvalidRecurrenceRuleException("without 'FREQ='")));
 
-		/**
-		 * COUNT and UNTIL must not occur in the same rule.
-		 */
-		mRules
-			.add(new TestRuleWithException("FREQ=DAILY;UNTIL=20130101;COUNT=12", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        /**
+         * Duplicate FREQ
+         */
+        mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYDAY=MO;FREQ=DAILY", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        // mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYDAY=MO;FREQ=DAILY", RfcMode.RFC5545_LAX).setException(new InvalidRecurrenceRuleException("")));
 
-		/**
-		 * Values are out of range.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYMONTH=13", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYHOUR=25", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYMINUTE=61", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYSECOND=61", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYMONTHDAY=32", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYMONHT=2", RfcMode.RFC5545_STRICT)
+            .setException(new InvalidRecurrenceRuleException("unknown keyword")));
 
-		/**
-		 * BYMONTHDAY must not occur if the FREQ is set to WEEKLY.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYMONTHDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        /**
+         * Missing value for BYxxx rule.
+         */
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYMONTH=", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYMONTH=", RfcMode.RFC5545_LAX).setInstances(0));
 
-		/**
-		 * BYYEARDAY must only occur together with FREQ=YEARLY.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYYEARDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYYEARDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=DAILY;BYYEARDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        /**
+         * Invalid delimiter.
+         */
+        mRules.add(new TestRuleWithException("FREQ=YEARLY,BYMONTH=27", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
 
-		/**
-		 * BYWEEKNO must only be used when FREQ=YEARLY.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC5545_LAX).setObligatoryRuleParts("FREQ=YEARLY"));
-		mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC2445_LAX).setObligatoryRuleParts("FREQ=YEARLY"));
+        /**
+         * COUNT and UNTIL must not occur in the same rule.
+         */
+        mRules
+            .add(new TestRuleWithException("FREQ=DAILY;UNTIL=20130101;COUNT=12", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
 
-		/**
-		 * BYSETPOS must only be used in conjunction with another BYxxx rule.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1;COUNT=2", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1;COUNT=2", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1", RfcMode.RFC5545_LAX).setInvalidRules("BYSETPOS="));
+        /**
+         * Values are out of range.
+         */
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYMONTH=13", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYHOUR=25", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYMINUTE=61", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYSECOND=61", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYMONTHDAY=32", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
 
-		mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYDAY=-2SO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC5545_LAX).setInvalidRules("BYDAY="));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC5545_LAX).setInvalidRules("BYDAY="));
-		mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC2445_STRICT).setInvalidRules("BYDAY="));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC2445_STRICT).setInvalidRules("BYDAY="));
-		mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC2445_LAX).setInvalidRules("BYDAY="));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC2445_LAX).setInvalidRules("BYDAY="));
+        /**
+         * BYMONTHDAY must not occur if the FREQ is set to WEEKLY.
+         */
+        mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYMONTHDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
 
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYDAY=MO;COUNT=MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;BYDAY=MO;INTERVAL=MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        /**
+         * BYYEARDAY must only occur together with FREQ=YEARLY.
+         */
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYYEARDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=WEEKLY;BYYEARDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=DAILY;BYYEARDAY=7", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
 
-		/**
-		 * X-Parts in RFC 5545 modes. Lax mode should drop the part, strict mode must throw.
-		 */
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;X-MILLISECONDS=11,2,3,4", RfcMode.RFC5545_LAX).setInvalidRules("X-MILLISECONDS="));
-		mRules.add(new TestRuleWithException("FREQ=YEARLY;X-MILLISECONDS=11,2,3,4", RfcMode.RFC5545_STRICT)
-			.setException(new InvalidRecurrenceRuleException("")));
+        /**
+         * BYWEEKNO must only be used when FREQ=YEARLY.
+         */
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC5545_LAX).setObligatoryRuleParts("FREQ=YEARLY"));
+        mRules.add(new TestRuleWithException("FREQ=MONTHLY;BYWEEKNO=26", RfcMode.RFC2445_LAX).setObligatoryRuleParts("FREQ=YEARLY"));
 
-		/**
-		 * UNTIL value is invalid, these are examples from the wild
-		 */
-		mRules.add(new TestRuleWithException("FREQ=WEEKLY;UNTIL=20140801T150000ZZ;INTERVAL=1;BYDAY=MO", RfcMode.RFC5545_STRICT)
-			.setException(new InvalidRecurrenceRuleException("")));
-		mRules.add(new TestRuleWithException("FREQ=WEEKLY;UNTIL=20140801T150000ZZ;INTERVAL=1;BYDAY=MO", RfcMode.RFC2445_STRICT)
-			.setException(new InvalidRecurrenceRuleException("")));
+        /**
+         * BYSETPOS must only be used in conjunction with another BYxxx rule.
+         */
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1;COUNT=2", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1;COUNT=2", RfcMode.RFC2445_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYSETPOS=1", RfcMode.RFC5545_LAX).setInvalidRules("BYSETPOS="));
 
-		/**
-		 * Test for other keywords.
-		 */
-		addUniqueKeyWordTests();
-		addInvalidWhiteSpaceTests();
+        mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYDAY=-2SO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC5545_LAX).setInvalidRules("BYDAY="));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC5545_LAX).setInvalidRules("BYDAY="));
+        mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC2445_STRICT).setInvalidRules("BYDAY="));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC2445_STRICT).setInvalidRules("BYDAY="));
+        mRules.add(new TestRuleWithException("FREQ=DAILY;BYDAY=+2MO", RfcMode.RFC2445_LAX).setInvalidRules("BYDAY="));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYWEEKNO=2;BYDAY=+1MO", RfcMode.RFC2445_LAX).setInvalidRules("BYDAY="));
 
-		for (TestRuleWithException rule : mRules)
-		{
-			if (rule.start == null)
-			{
-				rule.setStart(defaultStart);
-			}
-			boolean caughtException = false;
-			try
-			{
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYDAY=MO;COUNT=MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;BYDAY=MO;INTERVAL=MO", RfcMode.RFC5545_STRICT).setException(new InvalidRecurrenceRuleException("")));
 
-				RecurrenceRule r = new RecurrenceRule(rule.rule, rule.mode);
-				rule.assertInvalidRules(r.toString());
-				rule.assertObligatoryRuleParts(r.toString());
-				rule.setIterationStart(rule.start);
-				RecurrenceRuleIterator it = r.iterator(rule.start);
-				Set<DateTime> instances = new HashSet<DateTime>();
-				int count = 0;
-				while (it.hasNext())
-				{
-					DateTime instance = it.nextDateTime();
-					rule.testInstance(instance);
-					rule.assertInstances(count);
-					instances.add(instance);
-					count++;
-					if (count == RecurrenceIteratorTest.MAX_ITERATIONS)
-					{
-						break;
-					}
-				}
+        /**
+         * X-Parts in RFC 5545 modes. Lax mode should drop the part, strict mode must throw.
+         */
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;X-MILLISECONDS=11,2,3,4", RfcMode.RFC5545_LAX).setInvalidRules("X-MILLISECONDS="));
+        mRules.add(new TestRuleWithException("FREQ=YEARLY;X-MILLISECONDS=11,2,3,4", RfcMode.RFC5545_STRICT)
+            .setException(new InvalidRecurrenceRuleException("")));
 
-			}
-			catch (Exception e)
-			{
-				caughtException = true;
-				if (rule.exception != null)
-				{
+        /**
+         * UNTIL value is invalid, these are examples from the wild
+         */
+        mRules.add(new TestRuleWithException("FREQ=WEEKLY;UNTIL=20140801T150000ZZ;INTERVAL=1;BYDAY=MO", RfcMode.RFC5545_STRICT)
+            .setException(new InvalidRecurrenceRuleException("")));
+        mRules.add(new TestRuleWithException("FREQ=WEEKLY;UNTIL=20140801T150000ZZ;INTERVAL=1;BYDAY=MO", RfcMode.RFC2445_STRICT)
+            .setException(new InvalidRecurrenceRuleException("")));
 
-					if (!(e.getClass() == rule.exception.getClass()))
-					{
-						fail("Expected " + rule.exception + ", got " + e);
-					}
-				}
-				else
-				{
-					e.printStackTrace();
-					fail("Exception occured.");
-				}
+        /**
+         * Test for other keywords.
+         */
+        addUniqueKeyWordTests();
+        addInvalidWhiteSpaceTests();
 
-			}
-			if (!caughtException && rule.exception != null)
-			{
-				fail("Expected exception: " + rule.exception + " for rule " + rule.rule);
-			}
-		}
-	}
+        for (TestRuleWithException rule : mRules)
+        {
+            if (rule.start == null)
+            {
+                rule.setStart(defaultStart);
+            }
+            boolean caughtException = false;
+            try
+            {
+
+                RecurrenceRule r = new RecurrenceRule(rule.rule, rule.mode);
+                rule.assertInvalidRules(r.toString());
+                rule.assertObligatoryRuleParts(r.toString());
+                rule.setIterationStart(rule.start);
+                RecurrenceRuleIterator it = r.iterator(rule.start);
+                Set<DateTime> instances = new HashSet<DateTime>();
+                int count = 0;
+                while (it.hasNext())
+                {
+                    DateTime instance = it.nextDateTime();
+                    rule.testInstance(instance);
+                    rule.assertInstances(count);
+                    instances.add(instance);
+                    count++;
+                    if (count == RecurrenceIteratorTest.MAX_ITERATIONS)
+                    {
+                        break;
+                    }
+                }
+
+            }
+            catch (Exception e)
+            {
+                caughtException = true;
+                if (rule.exception != null)
+                {
+
+                    if (!(e.getClass() == rule.exception.getClass()))
+                    {
+                        fail("Expected " + rule.exception + ", got " + e);
+                    }
+                }
+                else
+                {
+                    e.printStackTrace();
+                    fail("Exception occured.");
+                }
+
+            }
+            if (!caughtException && rule.exception != null)
+            {
+                fail("Expected exception: " + rule.exception + " for rule " + rule.rule);
+            }
+        }
+    }
 }

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceRuleTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceRuleTest.java
@@ -19,27 +19,19 @@ package org.dmfs.rfc5545.recur;
 
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Weekday;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.SingleMatcher.hasValue;
-import static org.dmfs.rfc5545.Weekday.MO;
-import static org.dmfs.rfc5545.Weekday.TH;
-import static org.dmfs.rfc5545.Weekday.TU;
-import static org.dmfs.rfc5545.Weekday.WE;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.are;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.instances;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.results;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.startingWith;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.validRule;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.walking;
+import static org.dmfs.jems2.hamcrest.matchers.single.SingleMatcher.hasValue;
+import static org.dmfs.rfc5545.Weekday.*;
+import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.BeforeMatcher.before;
 import static org.dmfs.rfc5545.hamcrest.datetime.DayOfMonthMatcher.onDayOfMonth;
 import static org.dmfs.rfc5545.hamcrest.datetime.MonthMatcher.inMonth;
 import static org.dmfs.rfc5545.hamcrest.datetime.WeekDayMatcher.onWeekDay;
 import static org.dmfs.rfc5545.hamcrest.datetime.YearMatcher.inYear;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 
 /**
@@ -51,43 +43,55 @@ public final class RecurrenceRuleTest
     public void test() throws InvalidRecurrenceRuleException
     {
         assertThat(new RecurrenceRule("FREQ=WEEKLY;COUNT=1000"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(onWeekDay(MO))),
-                        results(1000))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(onWeekDay(MO))),
+                results(1000))));
 
         assertThat(new RecurrenceRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=+3TH;UNTIL=20140101T045959Z;WKST=SU"),
-                is(validRule(DateTime.parse("20130101T050000Z"),
-                        walking(),
-                        instances(are(onWeekDay(TH), onDayOfMonth(15, 16, 17, 18, 19, 20, 21), inYear(2013), before("20140101T050000Z"))),
-                        startingWith("20130117T050000Z", "20130221T050000Z", "20130321T050000Z"),
-                        results(12))));
+            is(validRule(DateTime.parse("20130101T050000Z"),
+                walking(),
+                instances(are(onWeekDay(TH), onDayOfMonth(15, 16, 17, 18, 19, 20, 21), inYear(2013), before("20140101T050000Z"))),
+                startingWith("20130117T050000Z", "20130221T050000Z", "20130321T050000Z"),
+                results(12))));
 
         // see https://github.com/dmfs/lib-recur/issues/73
         assertThat(new RecurrenceRule("FREQ=WEEKLY;INTERVAL=2;WKST=SU;BYDAY=TU;UNTIL=20200430T170000Z"),
-                is(validRule(DateTime.parse("20200404T100000Z"),
-                        walking(),
-                        instances(are(onWeekDay(TU), onDayOfMonth(14, 28), inMonth(4), inYear(2020), before("20200430T170000Z"))),
-                        startingWith("20200414T100000Z", "20200428T100000Z"),
-                        results(2))));
+            is(validRule(DateTime.parse("20200404T100000Z"),
+                walking(),
+                instances(are(onWeekDay(TU), onDayOfMonth(14, 28), inMonth(4), inYear(2020), before("20200430T170000Z"))),
+                startingWith("20200414T100000Z", "20200428T100000Z"),
+                results(2))));
 
         // see https://github.com/dmfs/lib-recur/issues/78
         assertThat(
-                () -> {
-                    RecurrenceRule recurrenceRule = new RecurrenceRule(Freq.MONTHLY);
-                    recurrenceRule.setCount(5);
-                    recurrenceRule.setInterval(1);
-                    recurrenceRule.setSkip(RecurrenceRule.Skip.FORWARD);
-                    recurrenceRule.setWeekStart(Weekday.MO);
-                    return recurrenceRule;
-                },
-                hasValue(hasToString("FREQ=MONTHLY;RSCALE=GREGORIAN;SKIP=FORWARD;COUNT=5"))
+            () -> {
+                RecurrenceRule recurrenceRule = new RecurrenceRule(Freq.MONTHLY);
+                recurrenceRule.setCount(5);
+                recurrenceRule.setInterval(1);
+                recurrenceRule.setSkip(RecurrenceRule.Skip.FORWARD);
+                recurrenceRule.setWeekStart(Weekday.MO);
+                return recurrenceRule;
+            },
+            hasValue(hasToString("FREQ=MONTHLY;RSCALE=GREGORIAN;SKIP=FORWARD;COUNT=5"))
         );
 
         assertThat(new RecurrenceRule("FREQ=MONTHLY;BYDAY=1MO,-1MO,WE"),
-                is(validRule(DateTime.parse("20200902"),
-                        walking(),
-                        instances(are(onWeekDay(MO, WE))),
-                        startingWith("20200902", "20200907", "20200909", "20200916", "20200923", "20200928", "20200930", "20201005", "20201007"))));
+            is(validRule(DateTime.parse("20200902"),
+                walking(),
+                instances(are(onWeekDay(MO, WE))),
+                startingWith("20200902", "20200907", "20200909", "20200916", "20200923", "20200928", "20200930", "20201005", "20201007"))));
+
+        assertThat(new RecurrenceRule("FREQ=WEEKLY;INTERVAL=2;BYHOUR=13;BYDAY=MO;COUNT=2"),
+            is(validRule(DateTime.parse("20201230T000000"),
+                walking(),
+                instances(are(onWeekDay(MO))),
+                startingWith("20210111T130000", "20210125T130000"))));
+
+        String ruleToTest = "FREQ=WEEKLY;BYMONTH=11;COUNT=1";
+        RecurrenceRule rule = new RecurrenceRule(ruleToTest);
+        RecurrenceRuleIterator iterator = rule.iterator(DateTime.parse("20210701T120000Z"));
+        System.out.println(rule.getByPart(RecurrenceRule.Part.BYMONTH));
+        System.out.println(rule.toString());
     }
 }

--- a/src/test/java/org/dmfs/rfc5545/recur/RecurrenceRuleYearlyTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/RecurrenceRuleYearlyTest.java
@@ -18,22 +18,18 @@
 package org.dmfs.rfc5545.recur;
 
 import org.dmfs.rfc5545.DateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.dmfs.rfc5545.Weekday.MO;
 import static org.dmfs.rfc5545.Weekday.TU;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.are;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.instances;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.startingWith;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.validRule;
-import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.walking;
+import static org.dmfs.rfc5545.hamcrest.RecurrenceRuleMatcher.*;
 import static org.dmfs.rfc5545.hamcrest.datetime.DayOfMonthMatcher.onDayOfMonth;
 import static org.dmfs.rfc5545.hamcrest.datetime.DayOfYearMatcher.onDayOfYear;
 import static org.dmfs.rfc5545.hamcrest.datetime.MonthMatcher.inMonth;
 import static org.dmfs.rfc5545.hamcrest.datetime.WeekDayMatcher.onWeekDay;
 import static org.dmfs.rfc5545.hamcrest.datetime.WeekOfYearMatcher.inWeekOfYear;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 
 /**
@@ -45,53 +41,53 @@ public final class RecurrenceRuleYearlyTest
     public void test() throws InvalidRecurrenceRuleException
     {
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYWEEKNO=1,10"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(inMonth(12, 1, 3), inWeekOfYear(1, 10), onWeekDay(MO) /* inherited weekday */)),
-                        startingWith("20180101", "20180305", "20181231", "20190304", "20191230", "20200302", "20210104", "20210308", "20220103", "20220307",
-                                "20230102", "20230306", "20240101", "20240304"))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(inMonth(12, 1, 3), inWeekOfYear(1, 10), onWeekDay(MO) /* inherited weekday */)),
+                startingWith("20180101", "20180305", "20181231", "20190304", "20191230", "20200302", "20210104", "20210308", "20220103", "20220307",
+                    "20230102", "20230306", "20240101", "20240304"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYWEEKNO=1,10;BYDAY=TU"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(inMonth(12, 1, 3), inWeekOfYear(1, 10), onWeekDay(TU))),
-                        startingWith("20180102", "20180306", "20190101", "20190305", "20191231", "20200303", "20210105", "20210309", "20220104", "20220308",
-                                "20230103", "20230307", "20240102", "20240305"))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(inMonth(12, 1, 3), inWeekOfYear(1, 10), onWeekDay(TU))),
+                startingWith("20180102", "20180306", "20190101", "20190305", "20191231", "20200303", "20210105", "20210309", "20220104", "20220308",
+                    "20230103", "20230307", "20240102", "20240305"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYWEEKNO=1,10;BYDAY=TU;BYMONTHDAY=3"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(inMonth(12, 1, 3), inWeekOfYear(1, 10), onWeekDay(TU), onDayOfMonth(3))),
-                        startingWith("20200303", "20230103"))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(inMonth(12, 1, 3), inWeekOfYear(1, 10), onWeekDay(TU), onDayOfMonth(3))),
+                startingWith("20200303", "20230103"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYYEARDAY=1,100"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(inMonth(1, 4), onDayOfYear(1, 100))),
-                        startingWith("20180101", "20180410", "20190101", "20190410", "20200101", "20200409", "20210101", "20210410", "20220101", "20220410"))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(inMonth(1, 4), onDayOfYear(1, 100))),
+                startingWith("20180101", "20180410", "20190101", "20190410", "20200101", "20200409", "20210101", "20210410", "20220101", "20220410"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYMONTH=1,2"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(inMonth(1, 2), onDayOfMonth(1))),
-                        startingWith("20180101", "20180201", "20190101", "20190201", "20200101", "20200201", "20210101", "20210201", "20220101", "20220201"))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(inMonth(1, 2), onDayOfMonth(1))),
+                startingWith("20180101", "20180201", "20190101", "20190201", "20200101", "20200201", "20210101", "20210201", "20220101", "20220201"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYMONTH=1,2;BYWEEKNO=1,7,20"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(inMonth(1, 2), inWeekOfYear(1, 7), onWeekDay(MO) /* inherited weekday */)),
-                        startingWith("20180101", "20180212", "20190211", "20200210", "20210104", "20210215", "20220103", "20220214"))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(inMonth(1, 2), inWeekOfYear(1, 7), onWeekDay(MO) /* inherited weekday */)),
+                startingWith("20180101", "20180212", "20190211", "20200210", "20210104", "20210215", "20220103", "20220214"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYWEEKNO=1,3,4,5,8,9;BYYEARDAY=1,14,31,60"),
-                is(validRule(DateTime.parse("20180101"),
-                        walking(),
-                        instances(are(inMonth(12, 1, 2, 3), inWeekOfYear(1, 3, 4, 5, 8, 9), onDayOfYear(1, 14, 31, 60))),
-                        startingWith("20180101", "20180131", "20180301", "20190101", "20190114", "20190131", "20190301", "20200101", "20200114", "20200131"))));
+            is(validRule(DateTime.parse("20180101"),
+                walking(),
+                instances(are(inMonth(12, 1, 2, 3), inWeekOfYear(1, 3, 4, 5, 8, 9), onDayOfYear(1, 14, 31, 60))),
+                startingWith("20180101", "20180131", "20180301", "20190101", "20190114", "20190131", "20190301", "20200101", "20200114", "20200131"))));
 
         assertThat(new RecurrenceRule("FREQ=YEARLY;BYMONTH=1,3;BYYEARDAY=1,14,31,32,60,61"),
-                is(validRule(DateTime.parse("20100101"),
-                        walking(),
-                        instances(are(inMonth(1, 3), onDayOfYear(1, 14, 31, 60, 61))),
-                        startingWith("20100101", "20100114", "20100131", "20100301", "20100302", "20110101", "20110114", "20110131"))));
+            is(validRule(DateTime.parse("20100101"),
+                walking(),
+                instances(are(inMonth(1, 3), onDayOfYear(1, 14, 31, 60, 61))),
+                startingWith("20100101", "20100114", "20100131", "20100301", "20100302", "20110101", "20110114", "20110131"))));
     }
 }

--- a/src/test/java/org/dmfs/rfc5545/recur/TestDate.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/TestDate.java
@@ -1,164 +1,164 @@
 package org.dmfs.rfc5545.recur;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.dmfs.rfc5545.DateTime;
 
 import java.util.TimeZone;
 
-import org.dmfs.rfc5545.DateTime;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class TestDate
 {
 
-	public final String dateTime;
-	public DateTime cal;
-	public int day, month, year;
-	public int hour = -1, minute = -1, second = -1;
-	public String timeZone;
-	public boolean isFloating = true;
-	public boolean isAllDay = true;
+    public final String dateTime;
+    public DateTime cal;
+    public int day, month, year;
+    public int hour = -1, minute = -1, second = -1;
+    public String timeZone;
+    public boolean isFloating = true;
+    public boolean isAllDay = true;
 
 
-	public TestDate(String rule)
-	{
-		this.dateTime = rule;
+    public TestDate(String rule)
+    {
+        this.dateTime = rule;
 
-	}
-
-
-	public TestDate setDate(int year, int month, int day)
-	{
-		this.year = year;
-		this.month = month;
-		this.day = day;
-		return this;
-	}
+    }
 
 
-	public TestDate setTime(int hour, int minute, int second)
-	{
-		this.hour = hour;
-		this.minute = minute;
-		this.second = second;
-		isAllDay = false;
-		return this;
-
-	}
+    public TestDate setDate(int year, int month, int day)
+    {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+        return this;
+    }
 
 
-	public TestDate setTimeZone(String tz)
-	{
-		timeZone = tz;
-		isFloating = false;
-		return this;
-	}
+    public TestDate setTime(int hour, int minute, int second)
+    {
+        this.hour = hour;
+        this.minute = minute;
+        this.second = second;
+        isAllDay = false;
+        return this;
+
+    }
 
 
-	public void testEvent()
-	{
-		cal = DateTime.parse(dateTime);
-		testFlags();
-		testDate();
-		testTime();
-		testToString();
-		testTimeZone();
-		testToAllDay();
-		testDate();
-
-	}
+    public TestDate setTimeZone(String tz)
+    {
+        timeZone = tz;
+        isFloating = false;
+        return this;
+    }
 
 
-	public void testDate()
-	{
-		assertEquals(day, cal.getDayOfMonth());
-		assertEquals(month, cal.getMonth());
-		assertEquals(year, cal.getYear());
-	}
+    public void testEvent()
+    {
+        cal = DateTime.parse(dateTime);
+        testFlags();
+        testDate();
+        testTime();
+        testToString();
+        testTimeZone();
+        testToAllDay();
+        testDate();
+
+    }
 
 
-	public void testTime()
-	{
-		if (!isAllDay)
-		{
-			assertEquals(hour, cal.getHours());
-			assertEquals(minute, cal.getMinutes());
-			assertEquals(second, cal.getSeconds());
-		}
-		else
-		{
-			assertTrue(cal.isAllDay());
-		}
-	}
+    public void testDate()
+    {
+        assertEquals(day, cal.getDayOfMonth());
+        assertEquals(month, cal.getMonth());
+        assertEquals(year, cal.getYear());
+    }
 
 
-	public void testToString()
-	{
-		assertEquals(dateTime, cal.toString());
-	}
+    public void testTime()
+    {
+        if (!isAllDay)
+        {
+            assertEquals(hour, cal.getHours());
+            assertEquals(minute, cal.getMinutes());
+            assertEquals(second, cal.getSeconds());
+        }
+        else
+        {
+            assertTrue(cal.isAllDay());
+        }
+    }
 
 
-	private void compareTwoCalendars(DateTime c1, DateTime c2)
-	{
-
-		assertEquals(c1.getYear(), c2.getYear());
-		assertEquals(c1.getMonth(), c2.getMonth());
-		assertEquals(c1.getDayOfMonth(), c2.getDayOfMonth());
-		assertEquals(c1.getHours(), c2.getHours());
-		assertEquals(c1.getMinutes(), c2.getMinutes());
-		assertEquals(c1.getSeconds(), c2.getSeconds());
-		assertEquals(c1.isAllDay(), c2.isAllDay());
-		assertEquals(c1.isFloating(), c2.isFloating());
-
-	}
+    public void testToString()
+    {
+        assertEquals(dateTime, cal.toString());
+    }
 
 
-	/**
-	 * Tests if isAllDay and isFloating are set correctly.
-	 */
-	public void testFlags()
-	{
-		assertEquals(isAllDay, cal.isAllDay());
-		assertEquals(isFloating, cal.isFloating());
-		if (isAllDay)
-		{
-			assertTrue(isFloating);
-		}
-	}
+    private void compareTwoCalendars(DateTime c1, DateTime c2)
+    {
+
+        assertEquals(c1.getYear(), c2.getYear());
+        assertEquals(c1.getMonth(), c2.getMonth());
+        assertEquals(c1.getDayOfMonth(), c2.getDayOfMonth());
+        assertEquals(c1.getHours(), c2.getHours());
+        assertEquals(c1.getMinutes(), c2.getMinutes());
+        assertEquals(c1.getSeconds(), c2.getSeconds());
+        assertEquals(c1.isAllDay(), c2.isAllDay());
+        assertEquals(c1.isFloating(), c2.isFloating());
+
+    }
 
 
-	public void testTimeZone()
-	{
-		if (!isFloating)
-		{
-			assertEquals(timeZone, cal.getTimeZone().getID());
-			DateTime calClone = cal.shiftTimeZone(TimeZone.getTimeZone(timeZone));
-			compareTwoCalendars(cal, calClone);
-		}
-		else
-		{
-			assertEquals(TimeZone.getTimeZone("UTC"), cal.getTimeZone());
-		}
-	}
+    /**
+     * Tests if isAllDay and isFloating are set correctly.
+     */
+    public void testFlags()
+    {
+        assertEquals(isAllDay, cal.isAllDay());
+        assertEquals(isFloating, cal.isFloating());
+        if (isAllDay)
+        {
+            assertTrue(isFloating);
+        }
+    }
 
 
-	public void testToAllDay()
-	{
-		DateTime calClone = cal.toAllDay();
-		assertEquals(0, calClone.getHours());
-		assertEquals(0, calClone.getMinutes());
-		assertEquals(0, calClone.getSeconds());
+    public void testTimeZone()
+    {
+        if (!isFloating)
+        {
+            assertEquals(timeZone, cal.getTimeZone().getID());
+            DateTime calClone = cal.shiftTimeZone(TimeZone.getTimeZone(timeZone));
+            compareTwoCalendars(cal, calClone);
+        }
+        else
+        {
+            assertEquals(TimeZone.getTimeZone("UTC"), cal.getTimeZone());
+        }
+    }
 
-		// date must stay the same
-		assertEquals(cal.getYear(), calClone.getYear());
-		assertEquals(cal.getMonth(), calClone.getMonth());
-		assertEquals(cal.getMonth(), calClone.getMonth());
 
-		assertTrue(calClone.isFloating());
-		assertTrue(calClone.isAllDay());
+    public void testToAllDay()
+    {
+        DateTime calClone = cal.toAllDay();
+        assertEquals(0, calClone.getHours());
+        assertEquals(0, calClone.getMinutes());
+        assertEquals(0, calClone.getSeconds());
 
-		assertEquals(TimeZone.getTimeZone("UTC"), calClone.getTimeZone());
+        // date must stay the same
+        assertEquals(cal.getYear(), calClone.getYear());
+        assertEquals(cal.getMonth(), calClone.getMonth());
+        assertEquals(cal.getMonth(), calClone.getMonth());
 
-	}
+        assertTrue(calClone.isFloating());
+        assertTrue(calClone.isAllDay());
+
+        assertEquals(TimeZone.getTimeZone("UTC"), calClone.getTimeZone());
+
+    }
 
 }

--- a/src/test/java/org/dmfs/rfc5545/recur/TestRule.java
+++ b/src/test/java/org/dmfs/rfc5545/recur/TestRule.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package org.dmfs.rfc5545.recur;
@@ -26,8 +26,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class TestRule
@@ -216,9 +215,7 @@ public class TestRule
     {
         if (count == -1 && until != null)
         {
-            String errMsg = "";
-            // errMsg = "instance " + instance + " after " + until + " in rule " + rule;
-            assertTrue(errMsg, !instance.after(until));
+            assertFalse(instance.after(until), () -> "instance " + instance + " after " + until + " in rule " + rule);
         }
     }
 
@@ -227,9 +224,7 @@ public class TestRule
     {
         if (months != null)
         {
-            String errMsg = "";
-            // errMsg = "month of " + instance + " not in " + months + " rule: " + rule;
-            assertTrue(errMsg, months.contains(instance.getMonth() + 1));
+            assertTrue(months.contains(instance.getMonth() + 1), () -> "month of " + instance + " not in " + months + " rule: " + rule);
         }
     }
 
@@ -238,9 +233,7 @@ public class TestRule
     {
         if (weekdays != null)
         {
-            String errMsg = "";
-             errMsg = "weekday of " + instance + " not in " + weekdays + " rule: " + rule;
-            assertTrue(errMsg, weekdays.contains(instance.getDayOfWeek() + 1));
+            assertTrue(weekdays.contains(instance.getDayOfWeek() + 1), () -> "weekday of " + instance + " not in " + weekdays + " rule: " + rule);
         }
     }
 
@@ -249,9 +242,7 @@ public class TestRule
     {
         if (monthdays != null)
         {
-            String errMsg = "";
-            errMsg = "monthday of " + instance + " not in " + monthdays + " rule: " + rule;
-            assertTrue(errMsg, monthdays.contains(instance.getDayOfMonth()));
+            assertTrue(monthdays.contains(instance.getDayOfMonth()), () -> "monthday of " + instance + " not in " + monthdays + " rule: " + rule);
         }
     }
 
@@ -260,9 +251,7 @@ public class TestRule
     {
         if (weeks != null)
         {
-            String errMsg = "";
-            // errMsg = "week of " + instance + " not in " + weeks + " rule: " + rule;
-            assertTrue(errMsg, weeks.contains(instance.getWeekOfYear()));
+            assertTrue(weeks.contains(instance.getWeekOfYear()), () -> "week of " + instance + " not in " + weeks + " rule: " + rule);
         }
     }
 
@@ -271,9 +260,7 @@ public class TestRule
     {
         if (hours != null)
         {
-            String errMsg = "";
-            // errMsg = "hour of " + instance + " not in " + hours + " rule: " + rule;
-            assertTrue(errMsg, hours.contains(instance.getHours()));
+            assertTrue(hours.contains(instance.getHours()), () -> "hour of " + instance + " not in " + hours + " rule: " + rule);
         }
     }
 
@@ -282,9 +269,7 @@ public class TestRule
     {
         if (minutes != null)
         {
-            String errMsg = "";
-            // errMsg = "minute of " + instance + " not in " + minutes + " rule: " + rule;
-            assertTrue(errMsg, minutes.contains(instance.getMinutes()));
+            assertTrue(minutes.contains(instance.getMinutes()), () -> "minute of " + instance + " not in " + minutes + " rule: " + rule);
         }
     }
 
@@ -293,9 +278,7 @@ public class TestRule
     {
         if (seconds != null)
         {
-            String errMsg = "";
-            // errMsg = "hour of " + instance + " not in " + seconds + " rule: " + rule;
-            assertTrue(errMsg, seconds.contains(instance.getSeconds()));
+            assertTrue(seconds.contains(instance.getSeconds()), () -> "hour of " + instance + " not in " + seconds + " rule: " + rule);
         }
     }
 
@@ -335,9 +318,7 @@ public class TestRule
     {
         if (this.instances > 0)
         {
-            String errMsg = "";
-            errMsg = "invalid number of instances for " + rule + " with start " + start;
-            assertEquals(errMsg, this.instances, instances);
+            assertEquals(this.instances, instances, () -> "invalid number of instances for " + rule + " with start " + start);
         }
     }
 }

--- a/src/test/java/org/dmfs/rfc5545/recurrenceset/RecurrenceRuleAdapterTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recurrenceset/RecurrenceRuleAdapterTest.java
@@ -19,12 +19,12 @@ package org.dmfs.rfc5545.recurrenceset;
 
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.recur.RecurrenceRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 /**
@@ -36,7 +36,7 @@ public class RecurrenceRuleAdapterTest
     public void testGetIteratorSyncedStartInfinite() throws Exception
     {
         AbstractRecurrenceAdapter.InstanceIterator iterator = new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY"))
-                .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
+            .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
 
         assertThat(iterator.hasNext(), is(true));
         assertThat(iterator.hasNext(), is(true));
@@ -56,7 +56,7 @@ public class RecurrenceRuleAdapterTest
     public void testGetIteratorSyncedStartWithCount() throws Exception
     {
         AbstractRecurrenceAdapter.InstanceIterator iterator = new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY;COUNT=3"))
-                .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
+            .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
 
         assertThat(iterator.hasNext(), is(true));
         assertThat(iterator.hasNext(), is(true));
@@ -76,7 +76,7 @@ public class RecurrenceRuleAdapterTest
     public void testGetIteratorSyncedStartWithUntil() throws Exception
     {
         AbstractRecurrenceAdapter.InstanceIterator iterator = new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY;UNTIL=20170312T113012Z"))
-                .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
+            .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
 
         assertThat(iterator.hasNext(), is(true));
         assertThat(iterator.hasNext(), is(true));
@@ -96,7 +96,7 @@ public class RecurrenceRuleAdapterTest
     public void testGetIteratorUnsyncedStartInfinite() throws Exception
     {
         AbstractRecurrenceAdapter.InstanceIterator iterator = new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY;BYMONTHDAY=11"))
-                .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
+            .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
 
         // note the unsynced start is not a result, it's added separately by `RecurrenceSet`
         assertThat(iterator.hasNext(), is(true));
@@ -117,7 +117,7 @@ public class RecurrenceRuleAdapterTest
     public void testGetIteratorUnsyncedStartWithCount() throws Exception
     {
         AbstractRecurrenceAdapter.InstanceIterator iterator = new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY;COUNT=3;BYMONTHDAY=11"))
-                .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
+            .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
 
         // note the unsynced start is not a result, it's added separately by `RecurrenceSet`
         assertThat(iterator.hasNext(), is(true));
@@ -135,7 +135,7 @@ public class RecurrenceRuleAdapterTest
     public void testGetIteratorUnsyncedStartWithUntil() throws Exception
     {
         AbstractRecurrenceAdapter.InstanceIterator iterator = new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY;UNTIL=20170312T113012Z;BYMONTHDAY=11"))
-                .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
+            .getIterator(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp());
 
         // note the unsynced start is not a result, it's added separately by `RecurrenceSet`
         assertThat(iterator.hasNext(), is(true));
@@ -165,10 +165,10 @@ public class RecurrenceRuleAdapterTest
     public void testGetLastInstance() throws Exception
     {
         assertThat(new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY;COUNT=10"))
-                        .getLastInstance(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp()),
-                is(DateTime.parse("Europe/Berlin", "20171010T113012").getTimestamp()));
+                .getLastInstance(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp()),
+            is(DateTime.parse("Europe/Berlin", "20171010T113012").getTimestamp()));
         assertThat(new RecurrenceRuleAdapter(new RecurrenceRule("FREQ=MONTHLY;UNTIL=20171212T101010Z"))
-                        .getLastInstance(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp()),
-                is(DateTime.parse("Europe/Berlin", "20171210T113012").getTimestamp()));
+                .getLastInstance(TimeZone.getTimeZone("Europe/Berlin"), DateTime.parse("Europe/Berlin", "20170110T113012").getTimestamp()),
+            is(DateTime.parse("Europe/Berlin", "20171210T113012").getTimestamp()));
     }
 }

--- a/src/test/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSetIteratorTest.java
+++ b/src/test/java/org/dmfs/rfc5545/recurrenceset/RecurrenceSetIteratorTest.java
@@ -17,22 +17,22 @@
 
 package org.dmfs.rfc5545.recurrenceset;
 
-import org.dmfs.iterators.AbstractBaseIterator;
+import org.dmfs.jems2.iterator.BaseIterator;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 import org.dmfs.rfc5545.recur.InvalidRecurrenceRuleException;
 import org.dmfs.rfc5545.recur.RecurrenceRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
-import static org.dmfs.jems.hamcrest.matchers.GeneratableMatcher.startsWith;
-import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.iteratorOf;
+import static org.dmfs.jems2.hamcrest.matchers.generatable.GeneratableMatcher.startsWith;
+import static org.dmfs.jems2.hamcrest.matchers.iterator.IteratorMatcher.iteratorOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 
 /**
@@ -380,7 +380,7 @@ public class RecurrenceSetIteratorTest
     }
 
 
-    private final static class RecurrenceAdapter extends AbstractBaseIterator<Long>
+    private final static class RecurrenceAdapter extends BaseIterator<Long>
     {
 
         private final RecurrenceSetIterator mDelegate;


### PR DESCRIPTION
fixes #35 #101

This commit deprecates the old recurrenceset implementation and adds a new one.
Handling of the first instance is now determined by chosing the right InstanceIterable, `RuleInstances` vs. `FirstAndRuleInstances`.

Also in this commit:

* Upgrade gradle -> gradle 7.4
* Upgrade jems -> jems2
* Upgrade JUnit -> Jupiter