### PR TITLE
Add test case for #75

### DIFF
--- a/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/RuleInstances.java
+++ b/src/main/java/org/dmfs/rfc5545/iterable/instanceiterable/RuleInstances.java
@@ -53,29 +53,27 @@ public final class RuleInstances implements InstanceIterable
     public InstanceIterator iterator(DateTime firstInstance)
     {
         RecurrenceRuleIterator iterator = mRrule.iterator(firstInstance);
+
         return new InstanceIterator()
         {
-            private final RecurrenceRuleIterator mIterator = iterator;
-
-
             @Override
             public boolean hasNext()
             {
-                return mIterator.hasNext();
+                return iterator.hasNext();
             }
 
 
             @Override
             public long next()
             {
-                return mIterator.nextMillis();
+                return iterator.nextMillis();
             }
 
 
             @Override
             public void fastForward(long until)
             {
-                mIterator.fastForward(until);
+                iterator.fastForward(until);
             }
         };
     }

--- a/src/test/java/org/dmfs/rfc5545/iterable/RecurrenceSetTest.java
+++ b/src/test/java/org/dmfs/rfc5545/iterable/RecurrenceSetTest.java
@@ -161,4 +161,39 @@ class RecurrenceSetTest
                 DateTime.parse("20220125")
             ));
     }
+
+
+    // see https://github.com/dmfs/lib-recur/issues/75
+    @Test
+    void testBySetPosWithOutOfSyncFirst() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new FirstAndRuleInstances(new RecurrenceRule("FREQ=MONTHLY;BYDAY=MO,FR;BYSETPOS=1,2,3;COUNT=6")
+                )),
+            iteratesTo(
+                DateTime.parse("20220101"),
+                DateTime.parse("20220103"),
+                DateTime.parse("20220107"),
+                DateTime.parse("20220204"),
+                DateTime.parse("20220207"),
+                DateTime.parse("20220211")));
+    }
+
+
+    // see https://github.com/dmfs/lib-recur/issues/75
+    @Test
+    void testBySetPosWithSyncedFirst() throws InvalidRecurrenceRuleException
+    {
+        assertThat(new RecurrenceSet(DateTime.parse("20220101"),
+                new RuleInstances(new RecurrenceRule("FREQ=MONTHLY;BYDAY=MO,FR;BYSETPOS=1,2,3;COUNT=6")
+                )),
+            iteratesTo(
+                DateTime.parse("20220103"),
+                DateTime.parse("20220107"),
+                DateTime.parse("20220110"),
+                DateTime.parse("20220204"),
+                DateTime.parse("20220207"),
+                DateTime.parse("20220211")
+            ));
+    }
 }


### PR DESCRIPTION
Looks like there is nothing to do because it's already handled correctly, at elast when using `RecurrenceSet`.

closes #75